### PR TITLE
Add link field in Rules and Formatters

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,11 +248,12 @@ Here is an example of a configuration file:
     "rules": [
         // test that named parameters like {param} appear in both the source and target
         {
-            "type": "resource-matcher",
             "name": "resource-named-params",
+            "type": "resource-matcher",
             "description": "Ensure that named parameters that appear in the source string are also used in the translated string",
             "note": "The named parameter '{matchString}' from the source string does not appear in the target string",
-            "regexps": [ "\\{\\w+\\}" ]
+            "regexps": [ "\\{\\w+\\}" ],
+            "link": "https://github.com/ilib-js/i18nlint/blob/main/README.md"
         }
     ],
     "formatters": [

--- a/README.md
+++ b/README.md
@@ -459,6 +459,11 @@ Each declarative rule should have the following properties:
   in the source and target strings. If any one of those expressions
   matches in the source, but not the target, the rule will create
   a Result that will be formatted for the user.
+* link (String) - an URL to a website with a more complete explanation
+  of the problem that was found and how the problem can be resolved
+  and avoided in the future. Often, this is a link to a markdown file
+  in the docs folder on the github repo for the plugin, but it can be
+  any link you like.
 
 Programmatic rules are used when the requirements for the rules are more complicated
 than a simple regular expression string can handle. For example, a rule that checks
@@ -509,6 +514,22 @@ Declarative formatters are simply a template string where properties of the Resu
 instances are formatted into it. These can be declared in the config file. (See the
 example config file above.)
 
+The template strings may have any of the following fields from the Result instance
+in them:
+
+- severity
+- pathName
+- lineNumber
+- source
+- highlight
+- id
+
+Additionally, they may have the following fields from the Rule instance in them:
+
+- ruleDescription
+- ruleName
+- ruleLink
+
 Programmatic formatters are used when the requirements for formatting are more complicated
 than a simple template string can handle. For example, a CSV formatter would have to make
 sure that fields in a CSV file are escaped properly to conform to CSV syntax, and would
@@ -521,6 +542,8 @@ The constructor of this class should define the following properties:
 
 - `this.name` - a unique name for this formatter
 - `this.description` - a description of this type of formatter to display to users
+- `this.link` - (optional) a link to a web page that gives a more complete explanation
+  the the rule and how to resolve the problem it found
 
 The formatter should also override and implement the
 [format()](https://github.com/iLib-js/i18nlint-common/blob/main/src/Formatter.js) method,
@@ -562,6 +585,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 ## Release Notes
+
+### v1.2.0
+
+- added Rule links to give rule writers a way of giving a more complete explanation
+  of the rule and how to resolve the problem.
 
 ### v1.1.0
 

--- a/docs/resource-icu-plurals.md
+++ b/docs/resource-icu-plurals.md
@@ -1,0 +1,23 @@
+# resource-icu-plurals
+
+If you received this error, then there is a syntax error in your plural string in
+translation of a source string. Strings are expected to follow the ICU format
+plurals. More info can be found [here](https://formatjs.io/docs/core-concepts/icu-syntax/#plural-format).
+
+There may be multiple types of errors:
+
+- The source contains a plural, but the translation does not. Obviously, you need
+  to ask the translator to put in the correct plural.
+- The translation contains a plural, but it is not in the right syntax. Make sure
+  it follows the syntax as per above.
+- The translation contains a plural and it is in the right syntax, but it has the
+  wrong categories. Each locale uses a different set of categories of plurals. For
+  example, Russian uses "one", "few", and "other", whereas Japanese only uses
+  "other". The translator should know which categories their language uses and add
+  the appropriate categories to the plural or subtract the ones that are not
+  needed.
+- The translation contains a plural in the right syntax, but it uses plural categories
+  that the target locale does not need. In this case, simply remove the unneeded
+  plural category translation.
+
+  

--- a/docs/resource-icu-plurals.md
+++ b/docs/resource-icu-plurals.md
@@ -1,8 +1,8 @@
 # resource-icu-plurals
 
 If you received this error, then there is a syntax error in your plural string in
-translation of a source string. Strings are expected to follow the ICU format
-plurals. More info can be found [here](https://formatjs.io/docs/core-concepts/icu-syntax/#plural-format).
+the source String or in the translation string. Strings are expected to follow the
+ICU format plurals. More info can be found [here](https://formatjs.io/docs/core-concepts/icu-syntax/#plural-format).
 
 There may be multiple types of errors:
 

--- a/docs/resource-icu-plurals.md
+++ b/docs/resource-icu-plurals.md
@@ -19,5 +19,3 @@ There may be multiple types of errors:
 - The translation contains a plural in the right syntax, but it uses plural categories
   that the target locale does not need. In this case, simply remove the unneeded
   plural category translation.
-
-  

--- a/docs/resource-named-params.md
+++ b/docs/resource-named-params.md
@@ -1,0 +1,8 @@
+# resource-named-params
+
+Ensure that named parameters that appear in the source string are also used in the
+translated string. Named parameters have the syntax {name}. That is, they are a
+simple name surrounded by curly braces. The same parameter must also exist in the
+target string with the same name. Sometimes translators accidentally translate
+the name of the parameter. Also, if the target string contains a parameter that
+the source string does not, you will also get this error.

--- a/docs/resource-quote-style.md
+++ b/docs/resource-quote-style.md
@@ -1,0 +1,21 @@
+# resource-quote-style
+
+If you received this error in your project, that means that a string was found where:
+
+- the source string contains quotes
+- the target string does not contain quotes or the quotes are not correct for the
+  target locale
+
+Try adding quotes around the translation of the part of the source string that was
+quoted, or adjusting the quotes in the target string to be appropriate for the target
+locale.
+
+Example string with a problem:
+
+source in English: This is a “string” in English.
+target in German: Dies ist eine "Zeichenfolge" auf deutsch.
+
+This would be flagged because the target is using the ASCII quotes instead of the
+proper quotes in German. The correct proper quotes would look like this:
+
+target: Dies ist eine „Zeichenfolge“ auf deutsch.

--- a/docs/resource-unique-keys.md
+++ b/docs/resource-unique-keys.md
@@ -1,0 +1,6 @@
+# resource-unique-keys
+
+If you received this error, it means that there are multiple resources in your project
+that have the same unique key, making them not actually unique. To resolve this,
+try changing the unique key for one of the instances so that they are both actually
+unique.

--- a/docs/resource-url-match.md
+++ b/docs/resource-url-match.md
@@ -1,0 +1,7 @@
+# resource-url-match
+
+Ensure that URLs that appear in the source string are also used in the translated string.
+This rule checks the source string for anything that matches an URL. If found, the same
+URL must appear in the translation of the string as well. In some cases, you may want a
+different URL in the translation. In that case, this rule should be turned off for that
+string.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-lint",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "module": "./src/index.js",
     "type": "module",
     "bin": "./src/index.js",
@@ -71,7 +71,7 @@
     },
     "dependencies": {
         "@formatjs/intl": "^2.6.3",
-        "i18nlint-common": "^1.2.0",
+        "i18nlint-common": "^1.3.0",
         "ilib-common": "^1.1.3",
         "ilib-lint-plugin-test": "file:test/ilib-lint-plugin-test",
         "ilib-locale": "^1.2.2",

--- a/src/PluginManager.js
+++ b/src/PluginManager.js
@@ -39,14 +39,16 @@ export const regexRules = [
         name: "resource-url-match",
         description: "Ensure that URLs that appear in the source string are also used in the translated string",
         note: "URL '{matchString}' from the source string does not appear in the target string",
-        regexps: [ "((https?|github|ftps?|mailto|file|data|irc):\\/\\/)([\\da-zA-Z\\.-]+)\\.([a-zA-Z\\.]{2,6})([\\/\w\\.-]*)*\\/?" ]
+        regexps: [ "((https?|github|ftps?|mailto|file|data|irc):\\/\\/)([\\da-zA-Z\\.-]+)\\.([a-zA-Z\\.]{2,6})([\\/\w\\.-]*)*\\/?" ],
+        link: "https://github.com/ilib-js/i18nlint/docs/resource-url-match.md"
     },
     {
         type: "resource-matcher",
         name: "resource-named-params",
         description: "Ensure that named parameters that appear in the source string are also used in the translated string",
         note: "The named parameter '{matchString}' from the source string does not appear in the target string",
-        regexps: [ "\\{\\w+\\}" ]
+        regexps: [ "\\{\\w+\\}" ],
+        link: "https://github.com/ilib-js/i18nlint/docs/resource-named-params.md"
     }
 ];
 

--- a/src/PluginManager.js
+++ b/src/PluginManager.js
@@ -40,7 +40,7 @@ export const regexRules = [
         description: "Ensure that URLs that appear in the source string are also used in the translated string",
         note: "URL '{matchString}' from the source string does not appear in the target string",
         regexps: [ "((https?|github|ftps?|mailto|file|data|irc):\\/\\/)([\\da-zA-Z\\.-]+)\\.([a-zA-Z\\.]{2,6})([\\/\w\\.-]*)*\\/?" ],
-        link: "https://github.com/ilib-js/i18nlint/docs/resource-url-match.md"
+        link: "https://github.com/ilib-js/i18nlint/blob/main/docs/resource-url-match.md"
     },
     {
         type: "resource-matcher",
@@ -48,7 +48,7 @@ export const regexRules = [
         description: "Ensure that named parameters that appear in the source string are also used in the translated string",
         note: "The named parameter '{matchString}' from the source string does not appear in the target string",
         regexps: [ "\\{\\w+\\}" ],
-        link: "https://github.com/ilib-js/i18nlint/docs/resource-named-params.md"
+        link: "https://github.com/ilib-js/i18nlint/blob/main/docs/resource-named-params.md"
     }
 ];
 

--- a/src/formatters/AnsiConsoleFormatter.js
+++ b/src/formatters/AnsiConsoleFormatter.js
@@ -62,6 +62,9 @@ class AnsiConsoleFormatter extends Formatter {
         output = output.replace(/<e\d><\/e\d>/g, "\u001B[91m \u001B[0m");
         output = output.replace(/<e\d>/g, "\u001B[91m");
         output = output.replace(/<\/e\d>/g, "\u001B[0m");
+        if (result.rule.getLink()) {
+            output += `  More info: ${result.rule.getLink()}\n`;
+        }
         return output;
     }
 }

--- a/src/formatters/AnsiConsoleFormatter.js
+++ b/src/formatters/AnsiConsoleFormatter.js
@@ -62,7 +62,7 @@ class AnsiConsoleFormatter extends Formatter {
         output = output.replace(/<e\d><\/e\d>/g, "\u001B[91m \u001B[0m");
         output = output.replace(/<e\d>/g, "\u001B[91m");
         output = output.replace(/<\/e\d>/g, "\u001B[0m");
-        if (result.rule.getLink()) {
+        if (typeof(result.rule.getLink) === 'function' && result.rule.getLink()) {
             output += `  More info: ${result.rule.getLink()}\n`;
         }
         return output;

--- a/src/formatters/ConfigBasedFormatter.js
+++ b/src/formatters/ConfigBasedFormatter.js
@@ -75,7 +75,7 @@ export class ConfigBasedFormatter extends Formatter {
         let output = this.template;
         
         for (let prop of resultFields) {
-            output = output.replace(new RegExp(`{${prop}}`, "g"), result[prop]);
+            output = output.replace(new RegExp(`{${prop}}`, "g"), result[prop] || "");
         }
         output = output.replace(new RegExp("{ruleName}", "g"), result.rule.getName());
         output = output.replace(new RegExp("{ruleDescription}", "g"), result.rule.getDescription());
@@ -85,7 +85,8 @@ export class ConfigBasedFormatter extends Formatter {
         output = output.replace(/<\/e\d>/g, this.highlightEnd);
 
         if (typeof(result.rule.getLink) === 'function') {
-            output = output.replace(new RegExp("{ruleLink}", "g"), result.rule.getLink());
+            const link = result.rule.getLink() || "";
+            output = output.replace(new RegExp("{ruleLink}", "g"), link);
         }
         return output;
     }

--- a/src/formatters/ConfigBasedFormatter.js
+++ b/src/formatters/ConfigBasedFormatter.js
@@ -84,10 +84,11 @@ export class ConfigBasedFormatter extends Formatter {
         output = output.replace(/<e\d>/g, this.highlightStart);
         output = output.replace(/<\/e\d>/g, this.highlightEnd);
 
+        let link = "";
         if (typeof(result.rule.getLink) === 'function') {
-            const link = result.rule.getLink() || "";
-            output = output.replace(new RegExp("{ruleLink}", "g"), link);
+            link = result.rule.getLink() || "";
         }
+        output = output.replace(new RegExp("{ruleLink}", "g"), link);
         return output;
     }
 }

--- a/src/formatters/ConfigBasedFormatter.js
+++ b/src/formatters/ConfigBasedFormatter.js
@@ -83,6 +83,10 @@ export class ConfigBasedFormatter extends Formatter {
         output = output.replace(/<e\d><\/e\d>/g, `${this.highlightStart}${this.highlightEnd}`);
         output = output.replace(/<e\d>/g, this.highlightStart);
         output = output.replace(/<\/e\d>/g, this.highlightEnd);
+
+        if (typeof(result.rule.getLink) === 'function') {
+            output = output.replace(new RegExp("{ruleLink}", "g"), result.rule.getLink());
+        }
         return output;
     }
 }

--- a/src/rules/ResourceICUPlurals.js
+++ b/src/rules/ResourceICUPlurals.js
@@ -61,6 +61,7 @@ class ResourceICUPlurals extends Rule {
         this.name = "resource-icu-plurals";
         this.description = "Ensure that plurals in translated resources have the correct syntax";
         this.sourceLocale = (options && options.sourceLocale) || "en-US";
+        this.link = "https://gihub.com/ilib-js/i18nlint/docs/resource-icu-plurals.md";
     }
 
     getRuleType() {

--- a/src/rules/ResourceICUPlurals.js
+++ b/src/rules/ResourceICUPlurals.js
@@ -61,7 +61,7 @@ class ResourceICUPlurals extends Rule {
         this.name = "resource-icu-plurals";
         this.description = "Ensure that plurals in translated resources have the correct syntax";
         this.sourceLocale = (options && options.sourceLocale) || "en-US";
-        this.link = "https://gihub.com/ilib-js/i18nlint/docs/resource-icu-plurals.md";
+        this.link = "https://gihub.com/ilib-js/i18nlint/blob/main/docs/resource-icu-plurals.md";
     }
 
     getRuleType() {

--- a/src/rules/ResourceMatcher.js
+++ b/src/rules/ResourceMatcher.js
@@ -60,7 +60,7 @@ class ResourceMatcher extends Rule {
         if (!options || !options.name || !options.description || !options.note || !options.regexps) {
             throw "Missing required options for the ResourceMatcher constructor";
         }
-        ["name", "description", "regexps", "note", "sourceLocale"].forEach(prop => {
+        ["name", "description", "regexps", "note", "sourceLocale", "link"].forEach(prop => {
             this[prop] = options[prop];
         });
         this.sourceLocale = this.sourceLocale || "en-US";

--- a/src/rules/ResourceQuoteStyle.js
+++ b/src/rules/ResourceQuoteStyle.js
@@ -42,7 +42,7 @@ class ResourceQuoteStyle extends Rule {
             // only localized quotes are allowed in the target string
             this.localeOnly = true;
         }
-        this.link = "https://github.com/ilib-js/i18nlint/docs/resource-quote-style.md";
+        this.link = "https://github.com/ilib-js/i18nlint/blob/main/docs/resource-quote-style.md";
     }
 
     getRuleType() {

--- a/src/rules/ResourceQuoteStyle.js
+++ b/src/rules/ResourceQuoteStyle.js
@@ -42,6 +42,7 @@ class ResourceQuoteStyle extends Rule {
             // only localized quotes are allowed in the target string
             this.localeOnly = true;
         }
+        this.link = "https://github.com/ilib-js/i18nlint/docs/resource-quote-style.md";
     }
 
     getRuleType() {

--- a/src/rules/ResourceSourceChecker.js
+++ b/src/rules/ResourceSourceChecker.js
@@ -59,7 +59,7 @@ class ResourceMatcher extends Rule {
         if (!options || !options.name || !options.description || !options.note || !options.regexps) {
             throw "Missing required options for the ResourceMatcher constructor";
         }
-        ["name", "description", "regexps", "note", "sourceLocale"].forEach(prop => {
+        ["name", "description", "regexps", "note", "sourceLocale", "link"].forEach(prop => {
             this[prop] = options[prop];
         });
         this.sourceLocale = this.sourceLocale || "en-US";

--- a/src/rules/ResourceTargetChecker.js
+++ b/src/rules/ResourceTargetChecker.js
@@ -59,7 +59,7 @@ class ResourceMatcher extends Rule {
         if (!options || !options.name || !options.description || !options.note || !options.regexps) {
             throw "Missing required options for the ResourceMatcher constructor";
         }
-        ["name", "description", "regexps", "note", "sourceLocale"].forEach(prop => {
+        ["name", "description", "regexps", "note", "sourceLocale", "link"].forEach(prop => {
             this[prop] = options[prop];
         });
         this.sourceLocale = this.sourceLocale || "en-US";

--- a/src/rules/ResourceUniqueKeys.js
+++ b/src/rules/ResourceUniqueKeys.js
@@ -36,7 +36,7 @@ class ResourceUniqueKeys extends Rule {
         this.name = "resource-unique-keys";
         this.description = "Ensure that the keys are unique within a locale across all resource files";
         this.sourceLocale = (options && options.sourceLocale) || "en-US";
-        this.link = "https://github.com/ilib-js/i18nlint/docs/resource-unique-keys.md";
+        this.link = "https://github.com/ilib-js/i18nlint/blob/main/docs/resource-unique-keys.md";
         this.ts = new TranslationSet();
     }
 

--- a/src/rules/ResourceUniqueKeys.js
+++ b/src/rules/ResourceUniqueKeys.js
@@ -36,7 +36,7 @@ class ResourceUniqueKeys extends Rule {
         this.name = "resource-unique-keys";
         this.description = "Ensure that the keys are unique within a locale across all resource files";
         this.sourceLocale = (options && options.sourceLocale) || "en-US";
-
+        this.link = "https://github.com/ilib-js/i18nlint/docs/resource-unique-keys.md";
         this.ts = new TranslationSet();
     }
 

--- a/src/rules/SourceFileChecker.js
+++ b/src/rules/SourceFileChecker.js
@@ -59,7 +59,7 @@ class ResourceMatcher extends Rule {
         if (!options || !options.name || !options.description || !options.note || !options.regexps) {
             throw "Missing required options for the ResourceMatcher constructor";
         }
-        ["name", "description", "regexps", "note", "sourceLocale"].forEach(prop => {
+        ["name", "description", "regexps", "note", "sourceLocale", "link"].forEach(prop => {
             this[prop] = options[prop];
         });
         this.sourceLocale = this.sourceLocale || "en-US";

--- a/test/testFormatterManager.js
+++ b/test/testFormatterManager.js
@@ -56,7 +56,7 @@ export const testFormatterManager = {
 
         let formatter = mgr.get("minimal-formatter");
         test.ok(!formatter);
-        
+
         mgr.add([{
             "name": "minimal-formatter",
             "description": "A minimalistic formatter that only outputs the path and the highlight",
@@ -64,7 +64,7 @@ export const testFormatterManager = {
             "highlightStart": ">>",
             "highlightEnd": "<<"
         }]);
-        
+
         formatter = mgr.get("minimal-formatter");
         test.ok(formatter);
         test.equal(formatter.getName(), "minimal-formatter");
@@ -79,7 +79,7 @@ export const testFormatterManager = {
         test.ok(mgr);
 
         test.equal(mgr.size(), 1);
-        
+
         mgr.add([{
             "name": "minimal-formatter",
             "description": "A minimalistic formatter that only outputs the path and the highlight",
@@ -87,7 +87,7 @@ export const testFormatterManager = {
             "highlightStart": ">>",
             "highlightEnd": "<<"
         }]);
-        
+
         test.equal(mgr.size(), 2);
 
         test.done();
@@ -101,7 +101,7 @@ export const testFormatterManager = {
 
         let formatter = mgr.get("minimal-formatter");
         test.ok(!formatter);
-        
+
         mgr.add([{
             "name": "minimal-formatter",
             "description": "A minimalistic formatter that only outputs the path and the highlight",
@@ -109,7 +109,7 @@ export const testFormatterManager = {
             "highlightStart": ">>",
             "highlightEnd": "<<"
         }]);
-        
+
         formatter = mgr.get("minimal-formatter");
         test.ok(formatter);
 
@@ -130,6 +130,46 @@ export const testFormatterManager = {
             source: "test"
         }));
         const expected = "a/b/c/d.txt:\nTarget: Do not >>add<< the context.\n";
+        test.equal(actual, expected);
+        test.done();
+    },
+
+    testFormatterManagerFormatWithAllFields: function(test) {
+        test.expect(4);
+
+        const mgr = new FormatterManager();
+        test.ok(mgr);
+
+        let formatter = mgr.get("full-formatter");
+        test.ok(!formatter);
+
+        mgr.add([{
+            "name": "full-formatter",
+            "description": "A full formatter that outputs everything",
+            "template": "{id}\n{severity}\n{lineNumber}\n{source}\n{pathName}\n{highlight}\n{ruleDescription}\n{ruleName}\n{ruleLink}\n",
+            "highlightStart": ">>",
+            "highlightEnd": "<<"
+        }]);
+
+        const testrule = new ResourceMatcher({
+            "name": "x",
+            "description": "y",
+            "regexps":["test"],
+            "note": "q",
+            "sourceLocale": "en-US",
+            "link": "https://github.com/docs/index.md"
+        });
+        const actual = formatter.format(new Result({
+            pathName: "a/b/c/d.txt",
+            highlight: "Target: Do not <e0>add</e0> the context.",
+            severity: "error",
+            rule: testrule,
+            lineNumber: 2342,
+            description: `target string cannot contain the word "test"`,
+            id: "test.id",
+            source: "test"
+        }));
+        const expected = "test.id\nerror\n2342\ntest\na/b/c/d.txt\nTarget: Do not >>add<< the context.\ny\nx\nhttps://github.com/docs/index.md\n";
         test.equal(actual, expected);
         test.done();
     }

--- a/test/testFormatterManager.js
+++ b/test/testFormatterManager.js
@@ -159,6 +159,8 @@ export const testFormatterManager = {
             "sourceLocale": "en-US",
             "link": "https://github.com/docs/index.md"
         });
+        formatter = mgr.get("full-formatter");
+        test.ok(formatter);
         const actual = formatter.format(new Result({
             pathName: "a/b/c/d.txt",
             highlight: "Target: Do not <e0>add</e0> the context.",
@@ -170,6 +172,47 @@ export const testFormatterManager = {
             source: "test"
         }));
         const expected = "test.id\nerror\n2342\ntest\na/b/c/d.txt\nTarget: Do not >>add<< the context.\ny\nx\nhttps://github.com/docs/index.md\n";
+        test.equal(actual, expected);
+        test.done();
+    },
+
+    testFormatterManagerFormatWithAllFieldsSomeBlank: function(test) {
+        test.expect(4);
+
+        const mgr = new FormatterManager();
+        test.ok(mgr);
+
+        let formatter = mgr.get("full-formatter");
+        test.ok(!formatter);
+
+        mgr.add([{
+            "name": "full-formatter",
+            "description": "A full formatter that outputs everything",
+            "template": "{id}\n{severity}\n{lineNumber}\n{source}\n{pathName}\n{highlight}\n{ruleDescription}\n{ruleName}\n{ruleLink}\n",
+            "highlightStart": ">>",
+            "highlightEnd": "<<"
+        }]);
+
+        const testrule = new ResourceMatcher({
+            "name": "x",
+            "description": "y",
+            "regexps":["test"],
+            "note": "q",
+            "sourceLocale": "en-US",
+        });
+        formatter = mgr.get("full-formatter");
+        test.ok(formatter);
+        const actual = formatter.format(new Result({
+            pathName: "a/b/c/d.txt",
+            highlight: "Target: Do not <e0>add</e0> the context.",
+            severity: "error",
+            rule: testrule,
+            lineNumber: 2342,
+            description: `target string cannot contain the word "test"`,
+            id: "test.id",
+            source: "test"
+        }));
+        const expected = "test.id\nerror\n2342\ntest\na/b/c/d.txt\nTarget: Do not >>add<< the context.\ny\nx\n\n";
         test.equal(actual, expected);
         test.done();
     }


### PR DESCRIPTION
- Rules can now have a link field which gives the URL to a web page that explains the rule in more detail and what to do about it if your code does not pass this rule
- Formatters can now output the link as well
- Declarative formatters now have a ruleLink field they can put in the template string
- Some md pages were created for the built-in rules and links to github were put in