### PR TITLE
Implement a check for fullwidth chars in the target

### DIFF
--- a/docs/resource-no-fullwidth-digits.md
+++ b/docs/resource-no-fullwidth-digits.md
@@ -1,0 +1,8 @@
+# resource-no-fullwidth-digits
+
+Ensure that translations do not contain fullwidth digit characters. These should be represented as ASCII digits instead.
+
+Examples:
+
+Good translation: "Box12345"
+Bad translation: "Box１２３４５"

--- a/docs/resource-no-fullwidth-latin.md
+++ b/docs/resource-no-fullwidth-latin.md
@@ -1,0 +1,8 @@
+# resource-no-fullwidth-latin
+
+Ensure that translations do not contain fullwidth Latin characters. These should be represented as ASCII letters instead.
+
+Examples:
+
+Good translation: "Boxにアップロード"
+Bad translation: "Ｂｏｘにアップロード"

--- a/src/PluginManager.js
+++ b/src/PluginManager.js
@@ -52,13 +52,38 @@ export const regexRules = [
     },
     {
         type: "resource-target",
-        name: "resource-no-fullwidth",
-        description: "Ensure that the target does not contain any full width characters, digits, or punctuation.",
-        note: "The full width characters '{matchString}' are not allowed in the target string. Use ASCII instead.",
-        regexps: [ "[\\uFF01-\\uFFE6]+" ],
+        name: "resource-no-fullwidth-latin",
+        description: "Ensure that the target does not contain any full-width Latin characters.",
+        note: "The full-width characters '{matchString}' are not allowed in the target string. Use ASCII letters instead.",
+        regexps: [ "[\\uFF21-\\uFF3A\\uFF41-\\uFF5A]+" ],
         link: "https://github.com/ilib-js/i18nlint/blob/main/docs/resource-no-fullwidth.md"
+    },
+    {
+        type: "resource-target",
+        name: "resource-no-fullwidth-digits",
+        description: "Ensure that the target does not contain any full-width digits.",
+        note: "The full-width characters '{matchString}' are not allowed in the target string. Use ASCII digits instead.",
+        regexps: [ "[\\uFF10-\\uFF19]+" ],
+        link: "https://github.com/ilib-js/i18nlint/blob/main/docs/resource-no-fullwidth-digits.md"
     }
 ];
+
+// built-in ruleset that contains all the built-in rules
+export const builtInRulesets = {
+    generic: {
+        // programmatic rules
+        "resource-icu-plurals": true,
+        "resource-quote-style": true,
+        "resource-state-checker": true,
+        "resource-unique-keys": true,
+
+        // declarative rules from above
+        "resource-url-match": true,
+        "resource-named-params": true,
+        "resource-no-fullwidth-latin": true,
+        "resource-no-fullwidth-digits": true
+    }
+};
 
 /**
  * @private
@@ -154,9 +179,12 @@ class PluginManager {
                 this.ruleMgr.add(options.rulesData);
             }
             if (options.rulesets) {
-                this.ruleMgr.addRuleSets(options.rulesets);
+                this.ruleMgr.addRuleSetDefinitions(options.rulesets);
             }
         }
+
+        // add the default "generic" ruleset above
+        this.ruleMgr.addRuleSetDefinitions(builtInRulesets);
 
         // install the default formatter
         this.formatterMgr.add(AnsiConsoleFormatter);

--- a/src/PluginManager.js
+++ b/src/PluginManager.js
@@ -49,6 +49,14 @@ export const regexRules = [
         note: "The named parameter '{matchString}' from the source string does not appear in the target string",
         regexps: [ "\\{\\w+\\}" ],
         link: "https://github.com/ilib-js/i18nlint/blob/main/docs/resource-named-params.md"
+    },
+    {
+        type: "resource-target",
+        name: "resource-no-fullwidth",
+        description: "Ensure that the target does not contain any full width characters, digits, or punctuation.",
+        note: "The full width characters '{matchString}' are not allowed in the target string. Use ASCII instead.",
+        regexps: [ "[\\uFF01-\\uFFE6]+" ],
+        link: "https://github.com/ilib-js/i18nlint/blob/main/docs/resource-no-fullwidth.md"
     }
 ];
 

--- a/src/rules/ResourceMatcher.js
+++ b/src/rules/ResourceMatcher.js
@@ -66,7 +66,7 @@ class ResourceMatcher extends Rule {
         this.sourceLocale = this.sourceLocale || "en-US";
 
         // this may throw if you got to the regexp syntax wrong:
-        this.re = this.regexps.map(regexp => new RegExp(regexp, "g"));
+        this.re = this.regexps.map(regexp => new RegExp(regexp, "gu"));
     }
 
     getRuleType() {

--- a/test/testPluginManager.js
+++ b/test/testPluginManager.js
@@ -285,7 +285,7 @@ __Rule_(resource-test):_Test_for_the_existence_of_the_word_'test'_in_the_strings
     },
 
     testPluginManagerGetLoadPluginRightRuleSets: function(test) {
-        test.expect(8);
+        test.expect(7);
 
         const plgmgr = new PluginManager();
         test.ok(plgmgr);
@@ -303,10 +303,30 @@ __Rule_(resource-test):_Test_for_the_existence_of_the_word_'test'_in_the_strings
             test.ok(set);
             test.ok(set["resource-test"]);
             test.equal(typeof(set["resource-test"]), 'boolean');
-            test.ok(typeof(set["resource-test"]));
 
             test.done();
         });
+    },
+
+    testPluginManagerGetBuiltInRuleSets: function(test) {
+        test.expect(8);
+
+        const plgmgr = new PluginManager();
+        test.ok(plgmgr);
+        const rm = plgmgr.getRuleManager();
+        test.ok(rm);
+        const size = rm.sizeRuleSetDefinitions();
+
+        test.equal(rm.sizeRuleSetDefinitions(), 1);
+
+        const set = rm.getRuleSetDefinition("generic");
+        test.ok(set);
+        test.ok(set["resource-icu-plurals"]);
+        test.ok(set["resource-url-match"]);
+        test.equal(typeof(set["resource-icu-plurals"]), 'boolean');
+        test.equal(typeof(set["resource-url-match"]), 'boolean');
+
+        test.done();
     }
 };
 

--- a/test/testResourceTargetChecker.js
+++ b/test/testResourceTargetChecker.js
@@ -24,7 +24,7 @@ import { regexRules } from '../src/PluginManager.js';
 import { Result } from 'i18nlint-common';
 
 export const testResourceTargetChecker = {
-    testResourceNoFullwidth: function(test) {
+    testResourceNoFullwidthLatin: function(test) {
         test.expect(9);
 
         const rule = new ResourceTargetChecker(regexRules[2]);
@@ -47,7 +47,7 @@ export const testResourceTargetChecker = {
 
         test.equal(actual[0].severity, "error");
         test.equal(actual[0].id, "matcher.test");
-        test.equal(actual[0].description, "The full width characters 'Ｂｏｘ' are not allowed in the target string. Use ASCII instead.");
+        test.equal(actual[0].description, "The full-width characters 'Ｂｏｘ' are not allowed in the target string. Use ASCII letters instead.");
         test.equal(actual[0].highlight, "Target: <e0>Ｂｏｘ</e0>にアップロード");
         test.equal(actual[0].source, 'Upload to Box');
         test.equal(actual[0].pathName, "x/y");
@@ -55,7 +55,7 @@ export const testResourceTargetChecker = {
         test.done();
     },
 
-    testResourceNoFullwidthSuccess: function(test) {
+    testResourceNoFullwidthLatinSuccess: function(test) {
         test.expect(2);
 
         const rule = new ResourceTargetChecker(regexRules[2]);
@@ -78,7 +78,7 @@ export const testResourceTargetChecker = {
         test.done();
     },
 
-    testResourceNoFullwidthMultiple: function(test) {
+    testResourceNoFullwidthLatinMultiple: function(test) {
         test.expect(15);
 
         const rule = new ResourceTargetChecker(regexRules[2]);
@@ -101,16 +101,108 @@ export const testResourceTargetChecker = {
 
         test.equal(actual[0].severity, "error");
         test.equal(actual[0].id, "matcher.test");
-        test.equal(actual[0].description, "The full width characters 'Ｂｏｘ' are not allowed in the target string. Use ASCII instead.");
+        test.equal(actual[0].description, "The full-width characters 'Ｂｏｘ' are not allowed in the target string. Use ASCII letters instead.");
         test.equal(actual[0].highlight, "Target: プロ<e0>Ｂｏｘ</e0>にアップロードＢｏｘ");
         test.equal(actual[0].source, 'Upload to Box');
         test.equal(actual[0].pathName, "x/y");
 
         test.equal(actual[1].severity, "error");
         test.equal(actual[1].id, "matcher.test");
-        test.equal(actual[1].description, "The full width characters 'Ｂｏｘ' are not allowed in the target string. Use ASCII instead.");
+        test.equal(actual[1].description, "The full-width characters 'Ｂｏｘ' are not allowed in the target string. Use ASCII letters instead.");
         test.equal(actual[1].highlight, "Target: プロＢｏｘにアップロード<e0>Ｂｏｘ</e0>");
         test.equal(actual[1].source, 'Upload to Box');
+        test.equal(actual[1].pathName, "x/y");
+
+        test.done();
+    },
+
+    testResourceNoFullwidthDigits: function(test) {
+        test.expect(9);
+
+        const rule = new ResourceTargetChecker(regexRules[3]);
+        test.ok(rule);
+
+        const actual = rule.match({
+            locale: "ja-JP",
+            resource: new ResourceString({
+                key: "matcher.test",
+                sourceLocale: "en-US",
+                source: 'Box12345',
+                targetLocale: "ja-JP",
+                target: "Box１２３４５",
+                pathName: "a/b/c.xliff"
+            }),
+            file: "x/y"
+        });
+        test.ok(actual);
+        test.equal(actual.length, 1);
+
+        test.equal(actual[0].severity, "error");
+        test.equal(actual[0].id, "matcher.test");
+        test.equal(actual[0].description, "The full-width characters '１２３４５' are not allowed in the target string. Use ASCII digits instead.");
+        test.equal(actual[0].highlight, "Target: Box<e0>１２３４５</e0>");
+        test.equal(actual[0].source, 'Box12345');
+        test.equal(actual[0].pathName, "x/y");
+
+        test.done();
+    },
+
+    testResourceNoFullwidthDigitsSuccess: function(test) {
+        test.expect(2);
+
+        const rule = new ResourceTargetChecker(regexRules[3]);
+        test.ok(rule);
+
+        const actual = rule.match({
+            locale: "ja-JP",
+            resource: new ResourceString({
+                key: "matcher.test",
+                sourceLocale: "en-US",
+                source: 'Upload to Box',
+                targetLocale: "ja-JP",
+                target: "Boxにアップロード",
+                pathName: "a/b/c.xliff"
+            }),
+            file: "x/y"
+        });
+        test.ok(!actual);
+
+        test.done();
+    },
+
+    testResourceNoFullwidthDigitsMultiple: function(test) {
+        test.expect(15);
+
+        const rule = new ResourceTargetChecker(regexRules[3]);
+        test.ok(rule);
+
+        const actual = rule.match({
+            locale: "ja-JP",
+            resource: new ResourceString({
+                key: "matcher.test",
+                sourceLocale: "en-US",
+                source: '12345Box12345',
+                targetLocale: "ja-JP",
+                target: "５４３２１Box１２３４５",
+                pathName: "a/b/c.xliff"
+            }),
+            file: "x/y"
+        });
+        test.ok(actual);
+        test.equal(actual.length, 2);
+
+        test.equal(actual[0].severity, "error");
+        test.equal(actual[0].id, "matcher.test");
+        test.equal(actual[0].description, "The full-width characters '５４３２１' are not allowed in the target string. Use ASCII digits instead.");
+        test.equal(actual[0].highlight, "Target: <e0>５４３２１</e0>Box１２３４５");
+        test.equal(actual[0].source, '12345Box12345');
+        test.equal(actual[0].pathName, "x/y");
+
+        test.equal(actual[1].severity, "error");
+        test.equal(actual[1].id, "matcher.test");
+        test.equal(actual[1].description, "The full-width characters '１２３４５' are not allowed in the target string. Use ASCII digits instead.");
+        test.equal(actual[1].highlight, "Target: ５４３２１Box<e0>１２３４５</e0>");
+        test.equal(actual[1].source, '12345Box12345');
         test.equal(actual[1].pathName, "x/y");
 
         test.done();

--- a/test/testResourceTargetChecker.js
+++ b/test/testResourceTargetChecker.js
@@ -1,0 +1,119 @@
+/*
+ * testResourceTargetChecker.js - test the built-in regular-expression-based rules
+ *
+ * Copyright © 2023 JEDLSoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ResourceString } from 'ilib-tools-common';
+
+import ResourceTargetChecker from '../src/rules/ResourceTargetChecker.js';
+import { regexRules } from '../src/PluginManager.js';
+
+import { Result } from 'i18nlint-common';
+
+export const testResourceTargetChecker = {
+    testResourceNoFullwidth: function(test) {
+        test.expect(9);
+
+        const rule = new ResourceTargetChecker(regexRules[2]);
+        test.ok(rule);
+
+        const actual = rule.match({
+            locale: "ja-JP",
+            resource: new ResourceString({
+                key: "matcher.test",
+                sourceLocale: "en-US",
+                source: 'Upload to Box',
+                targetLocale: "ja-JP",
+                target: "Ｂｏｘにアップロード",
+                pathName: "a/b/c.xliff"
+            }),
+            file: "x/y"
+        });
+        test.ok(actual);
+        test.equal(actual.length, 1);
+
+        test.equal(actual[0].severity, "error");
+        test.equal(actual[0].id, "matcher.test");
+        test.equal(actual[0].description, "The full width characters 'Ｂｏｘ' are not allowed in the target string. Use ASCII instead.");
+        test.equal(actual[0].highlight, "Target: <e0>Ｂｏｘ</e0>にアップロード");
+        test.equal(actual[0].source, 'Upload to Box');
+        test.equal(actual[0].pathName, "x/y");
+
+        test.done();
+    },
+
+    testResourceNoFullwidthSuccess: function(test) {
+        test.expect(2);
+
+        const rule = new ResourceTargetChecker(regexRules[2]);
+        test.ok(rule);
+
+        const actual = rule.match({
+            locale: "ja-JP",
+            resource: new ResourceString({
+                key: "matcher.test",
+                sourceLocale: "en-US",
+                source: 'Upload to Box',
+                targetLocale: "ja-JP",
+                target: "Boxにアップロード",
+                pathName: "a/b/c.xliff"
+            }),
+            file: "x/y"
+        });
+        test.ok(!actual);
+
+        test.done();
+    },
+
+    testResourceNoFullwidthMultiple: function(test) {
+        test.expect(15);
+
+        const rule = new ResourceTargetChecker(regexRules[2]);
+        test.ok(rule);
+
+        const actual = rule.match({
+            locale: "ja-JP",
+            resource: new ResourceString({
+                key: "matcher.test",
+                sourceLocale: "en-US",
+                source: 'Upload to Box',
+                targetLocale: "ja-JP",
+                target: "プロＢｏｘにアップロードＢｏｘ",
+                pathName: "a/b/c.xliff"
+            }),
+            file: "x/y"
+        });
+        test.ok(actual);
+        test.equal(actual.length, 2);
+
+        test.equal(actual[0].severity, "error");
+        test.equal(actual[0].id, "matcher.test");
+        test.equal(actual[0].description, "The full width characters 'Ｂｏｘ' are not allowed in the target string. Use ASCII instead.");
+        test.equal(actual[0].highlight, "Target: プロ<e0>Ｂｏｘ</e0>にアップロードＢｏｘ");
+        test.equal(actual[0].source, 'Upload to Box');
+        test.equal(actual[0].pathName, "x/y");
+
+        test.equal(actual[1].severity, "error");
+        test.equal(actual[1].id, "matcher.test");
+        test.equal(actual[1].description, "The full width characters 'Ｂｏｘ' are not allowed in the target string. Use ASCII instead.");
+        test.equal(actual[1].highlight, "Target: プロＢｏｘにアップロード<e0>Ｂｏｘ</e0>");
+        test.equal(actual[1].source, 'Upload to Box');
+        test.equal(actual[1].pathName, "x/y");
+
+        test.done();
+    }
+};
+

--- a/test/testSuiteFiles.js
+++ b/test/testSuiteFiles.js
@@ -24,6 +24,7 @@ const files = [
     "testPluginManager.js",
     "testProject.js",
     "testResourceMatcher.js",
+    "testResourceTargetChecker.js",
     "testRules.js",
     "testRuleManager.js",
     "testRuleSet.js",


### PR DESCRIPTION
- needed to fix the previously-untested resource target and source checker type of rules
- make sure to add the "u" flag while creating the regexp so that we can specify unicode chars in the regexp
- actual check is implemented as a regular expression declarative rule in PluginManager.js