### PR TITLE
Add rule to check for some fullwidth punctuations in resource target

### DIFF
--- a/README.md
+++ b/README.md
@@ -591,6 +591,10 @@ limitations under the License.
 
 ## Release Notes
 
+### v1.4.0
+
+- added rules to detect some double-byte (fullwidth) characters
+
 ### v1.3.0
 
 - added resource-state-checker Rule so that you can ensure that all

--- a/docs/resource-no-fullwidth-punctuation-subset.md
+++ b/docs/resource-no-fullwidth-punctuation-subset.md
@@ -1,0 +1,8 @@
+# resource-no-fullwidth-digits
+
+Ensure that translations do not contain fullwidth punctuation characters. These should be represented as ASCII symbols instead.
+
+Examples:
+
+Good translation: "本当? はい! 100%"
+Bad translation: "本当？ はい！ 100％"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-lint",
-    "version": "1.3.0",
+    "version": "1.4.0",
     "module": "./src/index.js",
     "type": "module",
     "bin": "./src/index.js",

--- a/src/PluginManager.js
+++ b/src/PluginManager.js
@@ -89,7 +89,8 @@ export const builtInRulesets = {
         "resource-url-match": true,
         "resource-named-params": true,
         "resource-no-fullwidth-latin": true,
-        "resource-no-fullwidth-digits": true
+        "resource-no-fullwidth-digits": true,
+        "resource-no-fullwidth-punctuation-subset": true
     }
 };
 

--- a/src/PluginManager.js
+++ b/src/PluginManager.js
@@ -65,6 +65,14 @@ export const regexRules = [
         note: "The full-width characters '{matchString}' are not allowed in the target string. Use ASCII digits instead.",
         regexps: [ "[\\uFF10-\\uFF19]+" ],
         link: "https://github.com/ilib-js/i18nlint/blob/main/docs/resource-no-fullwidth-digits.md"
+    },
+    {
+        type: "resource-target",
+        name: "resource-no-fullwidth-punctuation-subset",
+        description: "Ensure that the target does not contain specific full-width punctuation: percent sign, question mark, or exclamation mark.",
+        note: "The full-width characters '{matchString}' are not allowed in the target string. Use ASCII symbols instead.",
+        regexps: [ "[\\uFF01|\\uFF05|\\uFF1F]+" ],
+        link: "https://github.com/ilib-js/i18nlint/blob/main/docs/resource-no-fullwidth-punctuation-subset.md"
     }
 ];
 


### PR DESCRIPTION
Added a regex declarative rule that detects if some specific fullwidth punctuation symbols were used in target: percent sign, question mark, or exclamation mark.