### PR TITLE
Check if trans-unit is complete

### DIFF
--- a/README.md
+++ b/README.md
@@ -591,6 +591,10 @@ limitations under the License.
 
 ## Release Notes
 
+### Pending release
+
+- added rule to check if resources have both source and target defined
+
 ### v1.4.0
 
 - added rules to detect some double-byte (fullwidth) characters

--- a/docs/resource-completeness.md
+++ b/docs/resource-completeness.md
@@ -1,0 +1,24 @@
+# resource-completeness
+
+If you received this error, it means that there are resources in your project
+which don't have either source or target element defined. To resolve this, add missing elements.
+
+For xliff 1.2 complete resources might look like this:
+
+```xml
+    <trans-unit id="1" resname="example" restype="string" datatype="javascript">
+      <source>This is the source text.</source>
+      <target state="translated">Dies ist der Quelltext</target>
+    </trans-unit>
+```
+
+In xliff 2.0 resources, they might look like this:
+
+```xml
+    <unit id="1">
+      <segment>
+        <source>This is the source text.</source>
+        <target state="translated">Dies ist der Quelltext</target>
+      </segment>
+    </unit>
+```

--- a/src/PluginManager.js
+++ b/src/PluginManager.js
@@ -29,6 +29,7 @@ import AnsiConsoleFormatter from './formatters/AnsiConsoleFormatter.js';
 import ResourceICUPlurals from './rules/ResourceICUPlurals.js';
 import ResourceQuoteStyle from './rules/ResourceQuoteStyle.js';
 import ResourceUniqueKeys from './rules/ResourceUniqueKeys.js';
+import ResourceCompleteness from './rules/ResourceCompleteness.js';
 
 const logger = log4js.getLogger("i18nlint.PluginManager");
 
@@ -84,6 +85,7 @@ export const builtInRulesets = {
         "resource-quote-style": true,
         "resource-state-checker": true,
         "resource-unique-keys": true,
+        "resource-completeness": true,
 
         // declarative rules from above
         "resource-url-match": true,
@@ -179,7 +181,8 @@ class PluginManager {
         this.ruleMgr.add([
             ResourceICUPlurals,
             ResourceQuoteStyle,
-            ResourceUniqueKeys
+            ResourceUniqueKeys,
+            ResourceCompleteness,
         ]);
         this.ruleMgr.add(regexRules);
 

--- a/src/rules/ResourceCompleteness.js
+++ b/src/rules/ResourceCompleteness.js
@@ -18,6 +18,7 @@
  */
 
 import { Rule, Result } from "i18nlint-common";
+import Locale from "ilib-locale";
 
 /** Rule to check that a resource has both source and target elements */
 class ResourceCompleteness extends Rule {
@@ -47,6 +48,10 @@ class ResourceCompleteness extends Rule {
         const source = resource.getSource();
         const target = resource.getTarget();
 
+        // note: language specifiers for comparison - "en-US" should match "en-GB" (same language, only different region)
+        const sourceLangSpec = new Locale(resource.sourceLocale).getLangSpec();
+        const targetLangSpec = new Locale(resource.targetLocale).getLangSpec();
+
         const resultMetaProps = {
             id: resource.getKey(),
             rule: this,
@@ -57,8 +62,8 @@ class ResourceCompleteness extends Rule {
 
         // for each source string, a translation must be provided
         if (undefined === target && undefined !== source
-            // unless the target locale is the same as source locale
-            && (resource.targetLocale !== resource.sourceLocale)
+            // unless the target language is the same as source language
+            && (sourceLangSpec !== targetLangSpec)
             ) {
             return new Result({
                 ...resultMetaProps,

--- a/src/rules/ResourceCompleteness.js
+++ b/src/rules/ResourceCompleteness.js
@@ -1,0 +1,75 @@
+/*
+ * ResourceCompleteness.js - rule to check that a resource has both source and target elements
+ *
+ * Copyright © 2023 JEDLSoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Rule, Result } from "i18nlint-common";
+
+/** Rule to check that a resource has both source and target elements */
+class ResourceCompleteness extends Rule {
+    /** @readonly */ name = "resource-completeness";
+    /** @readonly */ description = "Ensure that resources are complete, i.e. have both source and target elements.";
+    /** @readonly */ link = "https://github.com/ilib-js/i18nlint/blob/main/docs/resource-completeness.md";
+    /** @readonly */ ruleType = "resource";
+
+    constructor() {
+        super({});
+    }
+
+    /** @override */
+    getRuleType() {
+        return this.ruleType;
+    }
+
+    /** Check that a given resource has both source and target tags set
+     * @override
+     * @param {object} options
+     * @param {import("ilib-tools-common").Resource} options.resource
+     * @param {string} options.file
+     * @param {string} options.locale
+     *
+     */
+    match({ resource, file, locale }) {
+        const elements = {
+            source: resource.getSource(),
+            target: resource.getTarget(),
+        };
+
+        const elementsExist = Object.entries(elements).map(([name, value]) => ({
+            name,
+            exists: value !== undefined,
+        }));
+
+        if (elementsExist.some((el) => !el.exists)) {
+            return new Result({
+                severity: "error",
+                id: resource.getKey(),
+                rule: this,
+                pathName: file,
+                source: elements.source,
+                locale,
+                highlight: `The following elements are missing in the resource: <e0>${elementsExist
+                    .filter((el) => !el.exists)
+                    .map((el) => el.name)
+                    .join(", ")}</e0>`,
+                description: "Resource must have both source and target element defined"
+            });
+        } else return /* no error*/;
+    }
+}
+
+export default ResourceCompleteness;

--- a/test/testRules.js
+++ b/test/testRules.js
@@ -1187,71 +1187,139 @@ export const testRules = {
         test.done();
     },
 
-    testResourceCompleteness: function(test) {
-        test.expect(5);
+    testResourceCompletenessResourceComplete: function(test) {
+        test.expect(2);
 
         const rule = new ResourceCompleteness();
         test.ok(rule);
 
-        const subjects = [
-            {},
-            { key: "completeness.test.source-missing", source: undefined },
-            { key: "completeness.test.target-missing", target: undefined },
-            { key: "completeness.test.both-missing", source: undefined, target: undefined },
-        ]
-            .map((overrides) => ({
-                key: "completeness.test",
+        const subject = {
+            locale: "de-DE",
+            file: "x/y",
+            resource: new ResourceString({
+                key: "resource-completeness-test.complete",
                 sourceLocale: "en-US",
                 source: "Some source string.",
                 targetLocale: "de-DE",
                 target: "Some target string.",
                 pathName: "completeness-test.xliff",
                 state: "translated",
-                ...overrides, // override some of properties
-            }))
-            .map((props) => new ResourceString(props))
-            .map((resource) => ({ locale: "de-DE", resource, file: "x/y" }));
-
-        const results = subjects.map((subject) => rule.match(subject));
-
-        test.equal(results[0], undefined);
-
-        const commonResultProps = {
-            severity: "error",
-            rule,
-            pathName: "x/y",
-            locale: "de-DE",
-            description: "Resource must have both source and target element defined",
+            }),
         };
-        
-        test.deepEqual(
-            results[1],
-            new Result({
-                ...commonResultProps,
-                id: "completeness.test.source-missing",
+
+        const result = rule.match(subject);
+        test.equal(result, undefined); // for a valid resource match result should not be produced
+        test.done();
+    },
+
+    testResourceCompletenessResourceSourceMissing: function(test) {
+        test.expect(2);
+
+        const rule = new ResourceCompleteness();
+        test.ok(rule);
+
+        const subject = {
+            locale: "de-DE",
+            file: "x/y",
+            resource: new ResourceString({
+                key: "resource-completeness-test.source-missing",
+                sourceLocale: "en-US",
                 source: undefined,
+                targetLocale: "de-DE",
+                target: "Some target string.",
+                pathName: "completeness-test.xliff",
+                state: "translated",
+            }),
+        };
+
+        const result = rule.match(subject);
+        test.deepEqual(
+            result,
+            new Result({
+                rule,
+                severity: "error",
+                pathName: "x/y",
+                locale: "de-DE",
+                source: undefined,
+                id: "resource-completeness-test.source-missing",
+                description: "Resource must have both source and target element defined",
                 highlight: "The following elements are missing in the resource: <e0>source</e0>",
             })
         );
-        test.deepEqual(
-            results[2],
-            new Result({
-                ...commonResultProps,
-                id: "completeness.test.target-missing",
+        test.done();
+    },
+
+    testResourceCompletenessResourceTargetMissing: function(test) {
+        test.expect(2);
+
+        const rule = new ResourceCompleteness();
+        test.ok(rule);
+
+        const subject = {
+            locale: "de-DE",
+            file: "x/y",
+            resource: new ResourceString({
+                key: "resource-completeness-test.target-missing",
+                sourceLocale: "en-US",
                 source: "Some source string.",
+                targetLocale: "de-DE",
+                target: undefined,
+                pathName: "completeness-test.xliff",
+                state: "translated",
+            }),
+        };
+
+        const result = rule.match(subject);
+        test.deepEqual(
+            result,
+            new Result({
+                rule,
+                severity: "error",
+                pathName: "x/y",
+                locale: "de-DE",
+                source: "Some source string.",
+                id: "resource-completeness-test.target-missing",
+                description: "Resource must have both source and target element defined",
                 highlight: "The following elements are missing in the resource: <e0>target</e0>",
             })
         );
-        test.deepEqual(
-            results[3],
-            new Result({
-                ...commonResultProps,
-                id: "completeness.test.both-missing",
+        test.done();
+    },
+
+    testResourceCompletenessResourceSourceAndTargetMissing: function(test) {
+        test.expect(2);
+
+        const rule = new ResourceCompleteness();
+        test.ok(rule);
+
+        const subject = {
+            locale: "de-DE",
+            file: "x/y",
+            resource: new ResourceString({
+                key: "resource-completeness-test.source-and-target-missing",
+                sourceLocale: "en-US",
                 source: undefined,
+                targetLocale: "de-DE",
+                target: undefined,
+                pathName: "completeness-test.xliff",
+                state: "translated",
+            }),
+        };
+
+        const result = rule.match(subject);
+        test.deepEqual(
+            result,
+            new Result({
+                rule,
+                severity: "error",
+                pathName: "x/y",
+                locale: "de-DE",
+                source: undefined,
+                id: "resource-completeness-test.source-and-target-missing",
+                description: "Resource must have both source and target element defined",
                 highlight: "The following elements are missing in the resource: <e0>source, target</e0>",
             })
         );
-
         test.done();
     }
 };

--- a/test/testRules.js
+++ b/test/testRules.js
@@ -1286,7 +1286,7 @@ export const testRules = {
         test.done();
     },
 
-    testResourceCompletenessResourceTargetMissingSameLocale: function(test) {
+    testResourceCompletenessResourceTargetMissingSameLanguage: function(test) {
         test.expect(2);
 
         const rule = new ResourceCompleteness();
@@ -1296,10 +1296,10 @@ export const testRules = {
             locale: "en-US",
             file: "x/y",
             resource: new ResourceString({
-                key: "resource-completeness-test.target-missing",
+                key: "resource-completeness-test.target-missing-same-language",
                 sourceLocale: "en-US",
                 source: "Some source string.",
-                targetLocale: "en-US",
+                targetLocale: "en-GB",
                 target: undefined,
                 pathName: "completeness-test.xliff",
                 state: "translated",
@@ -1307,7 +1307,10 @@ export const testRules = {
         };
 
         const result = rule.match(subject);
-        test.equal(result, undefined); // no error should be produced
+        // no error should be produced -
+        // en-US and en-GB have same language so target value is optional in this case
+        // (it can be ommited for those resources where target is equal to source)
+        test.equal(result, undefined);
         test.done()
     }
 };

--- a/test/testRules.js
+++ b/test/testRules.js
@@ -1212,7 +1212,7 @@ export const testRules = {
         test.done();
     },
 
-    testResourceCompletenessResourceSourceMissing: function(test) {
+    testResourceCompletenessResourceExtraTarget: function(test) {
         test.expect(2);
 
         const rule = new ResourceCompleteness();
@@ -1222,7 +1222,7 @@ export const testRules = {
             locale: "de-DE",
             file: "x/y",
             resource: new ResourceString({
-                key: "resource-completeness-test.source-missing",
+                key: "resource-completeness-test.extra-target",
                 sourceLocale: "en-US",
                 source: undefined,
                 targetLocale: "de-DE",
@@ -1237,13 +1237,13 @@ export const testRules = {
             result,
             new Result({
                 rule,
-                severity: "error",
+                severity: "warning",
                 pathName: "x/y",
                 locale: "de-DE",
                 source: undefined,
-                id: "resource-completeness-test.source-missing",
-                description: "Resource must have both source and target element defined",
-                highlight: "The following elements are missing in the resource: <e0>source</e0>",
+                id: "resource-completeness-test.extra-target",
+                description: "Extra target string in resource",
+                highlight: "<e0>Some target string.</e0>",
             })
         );
         test.done();
@@ -1279,27 +1279,27 @@ export const testRules = {
                 locale: "de-DE",
                 source: "Some source string.",
                 id: "resource-completeness-test.target-missing",
-                description: "Resource must have both source and target element defined",
-                highlight: "The following elements are missing in the resource: <e0>target</e0>",
+                description: "Missing target string in resource",
+                highlight: undefined,
             })
         );
         test.done();
     },
 
-    testResourceCompletenessResourceSourceAndTargetMissing: function(test) {
+    testResourceCompletenessResourceTargetMissingSameLocale: function(test) {
         test.expect(2);
 
         const rule = new ResourceCompleteness();
         test.ok(rule);
 
         const subject = {
-            locale: "de-DE",
+            locale: "en-US",
             file: "x/y",
             resource: new ResourceString({
-                key: "resource-completeness-test.source-and-target-missing",
+                key: "resource-completeness-test.target-missing",
                 sourceLocale: "en-US",
-                source: undefined,
-                targetLocale: "de-DE",
+                source: "Some source string.",
+                targetLocale: "en-US",
                 target: undefined,
                 pathName: "completeness-test.xliff",
                 state: "translated",
@@ -1307,20 +1307,8 @@ export const testRules = {
         };
 
         const result = rule.match(subject);
-        test.deepEqual(
-            result,
-            new Result({
-                rule,
-                severity: "error",
-                pathName: "x/y",
-                locale: "de-DE",
-                source: undefined,
-                id: "resource-completeness-test.source-and-target-missing",
-                description: "Resource must have both source and target element defined",
-                highlight: "The following elements are missing in the resource: <e0>source, target</e0>",
-            })
-        );
-        test.done();
+        test.equal(result, undefined); // no error should be produced
+        test.done()
     }
 };
 


### PR DESCRIPTION
Create a rule which ensures that in XLIFF files received from translation vendor, each trans-unit has both source and target elements defined.

TUs with missing target generate an error.
TUs with missing source (but existing target) generate a warning.