### PR TITLE
ICU Plural rule no longer checks the source string

### DIFF
--- a/README.md
+++ b/README.md
@@ -591,6 +591,14 @@ limitations under the License.
 
 ## Release Notes
 
+### v1.5.0
+
+- removed ability for the ICU plural rule to report results on the
+  source text
+    - now it only checks the target text
+    - a different rule should be implemented to check the
+      source text
+
 ### v1.4.0
 
 - added rules to detect some double-byte (fullwidth) characters

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-lint",
-    "version": "1.4.0",
+    "version": "1.5.0",
     "module": "./src/index.js",
     "type": "module",
     "bin": "./src/index.js",

--- a/test/testRules.js
+++ b/test/testRules.js
@@ -657,16 +657,8 @@ export const testRules = {
             }),
             file: "x/y"
         });
-        const expected = new Result({
-            severity: "error",
-            description: "Missing plural categories in source string: one. Expecting these: one, other",
-            id: "plural.test",
-            highlight: 'Source: {count, plural, other {This is plural}}<e0></e0>',
-            rule,
-            pathName: "x/y",
-            source: '{count, plural, other {This is plural}}'
-        });
-        test.deepEqual(actual, expected);
+        // this rule does not test for problems in the source string
+        test.ok(!actual);
 
         test.done();
     },


### PR DESCRIPTION
- since it is a resource rule, it should only check the translation or that parts of the translation matches things in the source string.
- a source rule should be checking the source string separately
- this way, the source and resource rules can be turned on and off independently