### PR TITLE
Fix checking of array and plural resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -594,6 +594,8 @@ limitations under the License.
 ### Pending release
 
 - added rule to check if resources have both source and target defined
+- fixed bug where resources of type array or plural were not getting
+  processed properly in the declarative rules
 
 ### v1.5.0
 

--- a/src/rules/ResourceMatcher.js
+++ b/src/rules/ResourceMatcher.js
@@ -146,13 +146,12 @@ class ResourceMatcher extends Rule {
                 const srcArray = resource.getSource();
                 const tarArray = resource.getTarget();
                 if (tarArray) {
-                    return srcArray.map((item, i) => {
+                    const results = srcArray.map((item, i) => {
                         if (i < tarArray.length && tarArray[i]) {
                             return checkRegExps(srcArray[i], tarArray[i]);
                         }
-                    }).filter(element => {
-                        return element;
-                    });
+                    }).flat().filter(element => element);
+                    return (results && results.length ? results : undefined);
                 }
                 break;
 
@@ -160,15 +159,10 @@ class ResourceMatcher extends Rule {
                 const srcPlural = resource.getSource();
                 const tarPlural = resource.getTarget();
                 if (tarPlural) {
-                    const hasQuotes = categories.find(category => {
-                        return (srcPlural[category] && srcPlural[category].contains(srcQuote));
-                    });
-
-                    if (hasQuotes) {
-                        return categories.map(category => {
-                            return checkRegExps(srcPlural.other, tarPlural[category]);
-                        });
-                    }
+                    const results = Object.keys(tarPlural).map(category => {
+                        return checkRegExps(srcPlural[category] || srcPlural.other, tarPlural[category]);
+                    }).flat().filter(element => element);
+                    return (results && results.length ? results : undefined);
                 }
                 break;
         }

--- a/src/rules/ResourceSourceChecker.js
+++ b/src/rules/ResourceSourceChecker.js
@@ -116,18 +116,20 @@ class ResourceSourceChecker extends Rule {
 
             case 'array':
                 const srcArray = resource.getSource();
-                return srcArray.map((item, i) => {
-                    return checkRegExps(srcArray[i]);
-                }).filter(element => {
-                    return element;
-                });
+                if (srcArray) {
+                    const results = srcArray.map((item, i) => {
+                        return checkRegExps(srcArray[i]);
+                    }).flat().filter(element => element);
+                    return (results && results.length ? results : undefined);
+                }
                 break;
 
             case 'plural':
                 const srcPlural = resource.getSource();
-                return categories.map(category => {
+                const results = Object.keys(srcPlural).map(category => {
                     if (srcPlural[category]) return checkRegExps(srcPlural[category]);
-                });
+                }).flat().filter(element => element);
+                return (results && results.length ? results : undefined);
                 break;
         }
     }

--- a/src/rules/ResourceTargetChecker.js
+++ b/src/rules/ResourceTargetChecker.js
@@ -122,13 +122,12 @@ class ResourceTargetChecker extends Rule {
                 const srcArray = resource.getSource();
                 const tarArray = resource.getTarget();
                 if (tarArray) {
-                    return srcArray.map((item, i) => {
+                    const results = srcArray.map((item, i) => {
                         if (i < tarArray.length && tarArray[i]) {
                             return checkRegExps(srcArray[i], tarArray[i]);
                         }
-                    }).filter(element => {
-                        return element;
-                    });
+                    }).flat().filter(element => element);
+                    return (results && results.length ? results : undefined);
                 }
                 break;
 
@@ -136,9 +135,10 @@ class ResourceTargetChecker extends Rule {
                 const srcPlural = resource.getSource();
                 const tarPlural = resource.getTarget();
                 if (tarPlural) {
-                    return categories.map(category => {
+                    const results = Object.keys(tarPlural).map(category => {
                         if (tarPlural[category]) return checkRegExps(srcPlural.other, tarPlural[category]);
-                    });
+                    }).flat().filter(element => element);
+                    return (results && results.length ? results : undefined);
                 }
                 break;
         }

--- a/test/testResourceMatcher.js
+++ b/test/testResourceMatcher.js
@@ -1,7 +1,7 @@
 /*
- * testRegExpRules.js - test the built-in regular-expression-based rules
+ * testResourceMatcher.js - test the built-in regular-expression-based rules
  *
- * Copyright © 2022 JEDLSoft
+ * Copyright © 2022-2023 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ResourceString } from 'ilib-tools-common';
+import { ResourceString, ResourceArray, ResourcePlural } from 'ilib-tools-common';
 
 import ResourceMatcher from '../src/rules/ResourceMatcher.js';
 import { regexRules } from '../src/PluginManager.js';
@@ -112,6 +112,90 @@ export const testResourceMatcher = {
         test.done();
     },
 
+    testResourceURLMatchArray: function(test) {
+        test.expect(2);
+
+        const rule = new ResourceMatcher(regexRules[0]);
+        test.ok(rule);
+
+        const actual = rule.match({
+            locale: "de-DE",
+            resource: new ResourceArray({
+                key: "url.test",
+                sourceLocale: "en-US",
+                source: [
+                    'This has an URL in it http://www.box.com'
+                ],
+                targetLocale: "de-DE",
+                target: [
+                    "Dies hat ein URL http://www.box.com"
+                ],
+                pathName: "a/b/c.xliff"
+            }),
+            file: "x/y"
+        });
+        test.ok(!actual);
+
+        test.done();
+    },
+
+    testResourceURLMatchPlural: function(test) {
+        test.expect(2);
+
+        const rule = new ResourceMatcher(regexRules[0]);
+        test.ok(rule);
+
+        const actual = rule.match({
+            locale: "de-DE",
+            resource: new ResourceArray({
+                key: "url.test",
+                sourceLocale: "en-US",
+                source: {
+                    one: 'This has an URL in it http://www.box.com',
+                    other: "x"
+                },
+                targetLocale: "de-DE",
+                target: {
+                    one: "Dies hat ein URL http://www.box.com",
+                    other: "y"
+                },
+                pathName: "a/b/c.xliff"
+            }),
+            file: "x/y"
+        });
+        test.ok(!actual);
+
+        test.done();
+    },
+
+    testResourceURLMatchPluralTargetDoesNotUseCategory: function(test) {
+        test.expect(2);
+
+        const rule = new ResourceMatcher(regexRules[0]);
+        test.ok(rule);
+
+        const actual = rule.match({
+            locale: "de-DE",
+            resource: new ResourceArray({
+                key: "url.test",
+                sourceLocale: "en-US",
+                source: {
+                    one: 'This has an URL in it http://www.box.com',
+                    other: "x"
+                },
+                targetLocale: "ja-JP",
+                target: {
+                    other: "y"
+                },
+                pathName: "a/b/c.xliff"
+            }),
+            file: "x/y"
+        });
+        test.ok(!actual);
+
+        test.done();
+    },
+
     testResourceURLMatchMismatch: function(test) {
         test.expect(9);
 
@@ -126,6 +210,80 @@ export const testResourceMatcher = {
                 source: 'This has an URL in it http://www.box.com',
                 targetLocale: "de-DE",
                 target: "Dies hat ein URL http://www.yahoo.com",
+                pathName: "a/b/c.xliff"
+            }),
+            file: "x/y"
+        });
+        test.ok(actual);
+        test.equal(actual.length, 1);
+
+        test.equal(actual[0].severity, "error");
+        test.equal(actual[0].id, "url.test");
+        test.equal(actual[0].description, "URL 'http://www.box.com' from the source string does not appear in the target string");
+        test.equal(actual[0].highlight, "Target: Dies hat ein URL http://www.yahoo.com<e0></e0>");
+        test.equal(actual[0].source, 'This has an URL in it http://www.box.com');
+        test.equal(actual[0].pathName, "x/y");
+
+        test.done();
+    },
+
+    testResourceURLMatchMismatchArray: function(test) {
+        test.expect(9);
+
+        const rule = new ResourceMatcher(regexRules[0]);
+        test.ok(rule);
+
+        const actual = rule.match({
+            locale: "de-DE",
+            resource: new ResourceArray({
+                key: "url.test",
+                sourceLocale: "en-US",
+                source: [
+                    'This has an URL in it http://www.box.com',
+                    'This also has an URL in it http://www.google.com'
+                ],
+                targetLocale: "de-DE",
+                target: [
+                    "Dies hat ein URL http://www.yahoo.com",
+                    "Dies hat auch ein URL darin http://www.google.com"
+                ],
+                pathName: "a/b/c.xliff"
+            }),
+            file: "x/y"
+        });
+        test.ok(actual);
+        test.equal(actual.length, 1);
+
+        test.equal(actual[0].severity, "error");
+        test.equal(actual[0].id, "url.test");
+        test.equal(actual[0].description, "URL 'http://www.box.com' from the source string does not appear in the target string");
+        test.equal(actual[0].highlight, "Target: Dies hat ein URL http://www.yahoo.com<e0></e0>");
+        test.equal(actual[0].source, 'This has an URL in it http://www.box.com');
+        test.equal(actual[0].pathName, "x/y");
+
+        test.done();
+    },
+
+    testResourceURLMatchMismatchPlural: function(test) {
+        test.expect(9);
+
+        const rule = new ResourceMatcher(regexRules[0]);
+        test.ok(rule);
+
+        const actual = rule.match({
+            locale: "de-DE",
+            resource: new ResourcePlural({
+                key: "url.test",
+                sourceLocale: "en-US",
+                source: {
+                    one: "This has an URL in it http://www.box.com",
+                    other: "This also has an URL in it http://www.google.com"
+                },
+                targetLocale: "de-DE",
+                target: {
+                    one: "Dies hat ein URL http://www.yahoo.com",
+                    other: "Dies hat auch ein URL darin http://www.google.com"
+                },
                 pathName: "a/b/c.xliff"
             }),
             file: "x/y"

--- a/test/testResourceTargetChecker.js
+++ b/test/testResourceTargetChecker.js
@@ -16,7 +16,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ResourceString } from 'ilib-tools-common';
+import { ResourceString, ResourceArray, ResourcePlural } from 'ilib-tools-common';
 
 import ResourceTargetChecker from '../src/rules/ResourceTargetChecker.js';
 import { regexRules } from '../src/PluginManager.js';
@@ -55,6 +55,77 @@ export const testResourceTargetChecker = {
         test.done();
     },
 
+    testResourceNoFullwidthLatinArray: function(test) {
+        test.expect(9);
+
+        const rule = new ResourceTargetChecker(regexRules[2]);
+        test.ok(rule);
+
+        const actual = rule.match({
+            locale: "ja-JP",
+            resource: new ResourceArray({
+                key: "matcher.test",
+                sourceLocale: "en-US",
+                source: [
+                    'Upload to Box'
+                ],
+                targetLocale: "ja-JP",
+                target: [
+                    "Ｂｏｘにアップロード"
+                ],
+                pathName: "a/b/c.xliff"
+            }),
+            file: "x/y"
+        });
+        test.ok(actual);
+        test.equal(actual.length, 1);
+
+        test.equal(actual[0].severity, "error");
+        test.equal(actual[0].id, "matcher.test");
+        test.equal(actual[0].description, "The full-width characters 'Ｂｏｘ' are not allowed in the target string. Use ASCII letters instead.");
+        test.equal(actual[0].highlight, "Target: <e0>Ｂｏｘ</e0>にアップロード");
+        test.equal(actual[0].source, 'Upload to Box');
+        test.equal(actual[0].pathName, "x/y");
+
+        test.done();
+    },
+
+    testResourceNoFullwidthLatinPlural: function(test) {
+        test.expect(9);
+
+        const rule = new ResourceTargetChecker(regexRules[2]);
+        test.ok(rule);
+
+        const actual = rule.match({
+            locale: "ja-JP",
+            resource: new ResourcePlural({
+                key: "matcher.test",
+                sourceLocale: "en-US",
+                source: {
+                    one: 'Upload it',
+                    other: 'Upload to Box'
+                },
+                targetLocale: "ja-JP",
+                target: {
+                    other: "Ｂｏｘにアップロード"
+                },
+                pathName: "a/b/c.xliff"
+            }),
+            file: "x/y"
+        });
+        test.ok(actual);
+        test.equal(actual.length, 1);
+
+        test.equal(actual[0].severity, "error");
+        test.equal(actual[0].id, "matcher.test");
+        test.equal(actual[0].description, "The full-width characters 'Ｂｏｘ' are not allowed in the target string. Use ASCII letters instead.");
+        test.equal(actual[0].highlight, "Target: <e0>Ｂｏｘ</e0>にアップロード");
+        test.equal(actual[0].source, 'Upload to Box');
+        test.equal(actual[0].pathName, "x/y");
+
+        test.done();
+    },
+
     testResourceNoFullwidthLatinSuccess: function(test) {
         test.expect(2);
 
@@ -69,6 +140,61 @@ export const testResourceTargetChecker = {
                 source: 'Upload to Box',
                 targetLocale: "ja-JP",
                 target: "Boxにアップロード",
+                pathName: "a/b/c.xliff"
+            }),
+            file: "x/y"
+        });
+        test.ok(!actual);
+
+        test.done();
+    },
+
+    testResourceNoFullwidthLatinSuccessArray: function(test) {
+        test.expect(2);
+
+        const rule = new ResourceTargetChecker(regexRules[2]);
+        test.ok(rule);
+
+        const actual = rule.match({
+            locale: "ja-JP",
+            resource: new ResourceArray({
+                key: "matcher.test",
+                sourceLocale: "en-US",
+                source: [
+                    'Upload to Box'
+                ],
+                targetLocale: "ja-JP",
+                target: [
+                    "Boxにアップロード"
+                ],
+                pathName: "a/b/c.xliff"
+            }),
+            file: "x/y"
+        });
+        test.ok(!actual);
+
+        test.done();
+    },
+
+    testResourceNoFullwidthLatinSuccessPlural: function(test) {
+        test.expect(2);
+
+        const rule = new ResourceTargetChecker(regexRules[2]);
+        test.ok(rule);
+
+        const actual = rule.match({
+            locale: "ja-JP",
+            resource: new ResourceArray({
+                key: "matcher.test",
+                sourceLocale: "en-US",
+                source: {
+                    one: "Upload it",
+                    other: "Upload to Box"
+                },
+                targetLocale: "ja-JP",
+                target: {
+                    other: "Boxにアップロード"
+                },
                 pathName: "a/b/c.xliff"
             }),
             file: "x/y"


### PR DESCRIPTION
- add unit tests for array and plural resources both positive and negative
- fix code to return the right results for resource matcher, resource source, and resource target types of declarative rules