### PR TITLE
Add rule to check Do Not Translate terms

### DIFF
--- a/README.md
+++ b/README.md
@@ -595,6 +595,7 @@ limitations under the License.
 
 - added rule to ensure whitespaces at the edges of string are preserved in the same form
 - added rule to check if resources have both source and target defined
+- added rule to check Do Not Translate terms in resources
 
 ### v1.5.0
 

--- a/docs/resource-dnt-terms.md
+++ b/docs/resource-dnt-terms.md
@@ -11,11 +11,12 @@ List of DNT terms can be provided directly in rule's config by setting them in p
 Alternatively, terms can be provided via an external file by setting `termsFilePath: string` and `termsFileType: "json" | "txt"`.  
 `termsFilePath` should contain either an absolute path, or relative to current working directory.  
 `termsFileType` is used to determine how the terms file should be parsed:
-- `txt` treats the file as plain text DNT terms, one in each line (separated by `\r\n` or `\n`):
+- `txt` treats the file as plain text DNT terms, one in each line (any kind of line ending):
 ```
 Some DNT term
 Another DNT term
 ```
+(it will also trim whitespace from beginning/end of the term and exclude empty lines)
 - `json` expects the file to contain a JSON file with `string[]` at its root:
 ```json
 [

--- a/docs/resource-dnt-terms.md
+++ b/docs/resource-dnt-terms.md
@@ -1,0 +1,25 @@
+# resource-dnt-terms
+
+Ensure that if a Do Not Translate term exists in source string, it also appears somewhere in the corresponding target string.
+
+If You received this error, ensure that the missing DNT term is included in an unchanged form in the translated string.
+
+## Configuration
+
+List of DNT terms can be provided directly in rule's config by setting them in property `terms: string[]`.
+
+Alternatively, terms can be provided via an external file by setting `termsFilePath: string` and `termsFileType: "json" | "txt"`.  
+`termsFilePath` should contain either an absolute path, or relative to current working directory.  
+`termsFileType` is used to determine how the terms file should be parsed:
+- `txt` treats the file as plain text DNT terms, one in each line (separated by `\r\n` or `\n`):
+```
+Some DNT term
+Another DNT term
+```
+- `json` expects the file to contain a JSON file with `string[]` at its root:
+```json
+[
+    "Some DNT term",
+    "Another DNT term"
+]
+```

--- a/src/PluginManager.js
+++ b/src/PluginManager.js
@@ -31,6 +31,7 @@ import ResourceQuoteStyle from './rules/ResourceQuoteStyle.js';
 import ResourceUniqueKeys from './rules/ResourceUniqueKeys.js';
 import ResourceEdgeWhitespace from './rules/ResourceEdgeWhitespace.js';
 import ResourceCompleteness from './rules/ResourceCompleteness.js';
+import ResourceDNTTerms from './rules/ResourceDNTTerms.js';
 
 const logger = log4js.getLogger("i18nlint.PluginManager");
 
@@ -186,6 +187,7 @@ class PluginManager {
             ResourceUniqueKeys,
             ResourceEdgeWhitespace,
             ResourceCompleteness,
+            ResourceDNTTerms,
         ]);
         this.ruleMgr.add(regexRules);
 

--- a/src/rules/ResourceDNTTerms.js
+++ b/src/rules/ResourceDNTTerms.js
@@ -32,7 +32,9 @@ class ResourceDNTTerms extends Rule {
      * @readonly
      * @type {string[]}
      */
-    dntTerms = [];
+    _dntTerms = [];
+    
+    get dntTerms() { return this._dntTerms; }
 
     constructor(
         /** @type {{terms?: string[]; termsFilePath?: string; termsFileType?: ("json"|"txt")}} */ {
@@ -65,7 +67,7 @@ class ResourceDNTTerms extends Rule {
             }
         }
 
-        this.dntTerms = [...new Set(terms.filter((t) => t.length > 0))];
+        this._dntTerms = [...new Set(terms.filter((t) => t.length > 0))];
     }
 
     /** @override */
@@ -99,7 +101,7 @@ class ResourceDNTTerms extends Rule {
 
         const /** @type {Result[]} */ results = [];
 
-        for (const term of this.dntTerms) {
+        for (const term of this._dntTerms) {
             if (source.includes(term) && !target.includes(term)) {
                 results.push(
                     new Result({

--- a/src/rules/ResourceDNTTerms.js
+++ b/src/rules/ResourceDNTTerms.js
@@ -1,0 +1,142 @@
+/*
+ * ResourceDNTTerms.js - rule to ensure that Do Not Translate terms have not been translated
+ *
+ * Copyright © 2023 JEDLSoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Rule, Result } from "i18nlint-common";
+import fs from "node:fs";
+
+/** Rule to ensure that Do Not Translate terms have not been translated;
+ * i.e., if a DNT term appears in source, it has to appear in target as well */
+class ResourceDNTTerms extends Rule {
+    /** @readonly */ name = "resource-dnt-terms";
+    /** @readonly */ description = "Ensure that Do Not Translate terms have not been translated.";
+    /** @readonly */ link = "https://github.com/ilib-js/i18nlint/blob/main/docs/resource-dnt-terms.md";
+    /** @readonly */ ruleType = "resource";
+
+    /**
+     * @readonly
+     * @type {string[]}
+     */
+    dntTerms = [];
+
+    constructor(
+        /** @type {{terms?: string[]; termsFilePath?: string; termsFileType?: ("json"|"txt")}} */ {
+            terms,
+            termsFilePath,
+            termsFileType = "json",
+        }
+    ) {
+        super({});
+
+        if (undefined === terms) {
+            // if the terms are not provided explicitly, parse them from a file
+            if (undefined === termsFilePath) {
+                throw new Error("Neither DNT terms nor path to a DNT terms file were provided");
+            }
+            switch (termsFileType) {
+                case "json":
+                    terms = ResourceDNTTerms._parseTermsFromJsonFile(termsFilePath);
+                    break;
+                case "txt":
+                    terms = ResourceDNTTerms._parseTermsFromTxtFile(termsFilePath);
+                    break;
+                default:
+                    throw new Error(`"${termsFileType}" is not a valid DNT terms file type`);
+            }
+        } else {
+            // ensure valid type
+            if (!Array.isArray(terms) || !terms.every((term) => "string" === typeof term)) {
+                throw new Error(`DNT terms provided in an unexpected format; expected string[]`);
+            }
+        }
+
+        this.dntTerms = [...new Set(terms.filter((t) => t.length > 0))];
+    }
+
+    /** @override */
+    getRuleType() {
+        return this.ruleType;
+    }
+
+    /** Check that a given resource has both source and target tags set
+     * @override
+     * @param {object} options
+     * @param {import("ilib-tools-common").Resource} options.resource
+     * @param {string} options.file
+     * @param {string} options.locale
+     *
+     */
+    match({ resource, file, locale }) {
+        const source = resource.getSource();
+        const target = resource.getTarget();
+
+        if ("string" !== typeof source || "string" !== typeof target) {
+            return /* don't check when either source or target string is not defined */;
+        }
+
+        const resultMetaProps = {
+            id: resource.getKey(),
+            rule: this,
+            pathName: file,
+            source,
+            locale,
+        };
+
+        const /** @type {Result[]} */ results = [];
+
+        for (const term of this.dntTerms) {
+            if (source.includes(term) && !target.includes(term)) {
+                results.push(
+                    new Result({
+                        ...resultMetaProps,
+                        severity: "error",
+                        description: "A DNT term is missing in target string.",
+                        highlight: `Missing term: <e0>${term}</e0>`,
+                    })
+                );
+            }
+        }
+
+        return results;
+    }
+
+    /** Parse DNT terms from a JSON `string[]` file
+     * @param path Path to a DNT dictionary stored as JSON `string[]` file
+     */
+    static _parseTermsFromJsonFile(/** @type {string} */ path) {
+        const text = fs.readFileSync(path, "utf8");
+        let content = undefined;
+        try {
+            content = JSON.parse(text);
+        } catch {
+            throw new Error(`Failed to parse DNT terms file as JSON`);
+        }
+        if (!Array.isArray(content) || !content.every((term) => "string" === typeof term)) {
+            throw new Error(`DNT terms JSON file has unexpected content; expected string[]`);
+        }
+        return /** @type {string[]} */ (content);
+    }
+
+    /** Parse DNT terms from a text file by treating each line in file as a separate term */
+    static _parseTermsFromTxtFile(/** @type {string} */ path) {
+        const text = fs.readFileSync(path, "utf8");
+        return text.split(/\r?\n/);
+    }
+}
+
+export default ResourceDNTTerms;

--- a/src/rules/ResourceDNTTerms.js
+++ b/src/rules/ResourceDNTTerms.js
@@ -29,14 +29,11 @@ class ResourceDNTTerms extends Rule {
     /** @readonly */ ruleType = "resource";
 
     /**
+     * @protected
      * @readonly
      * @type {string[]}
      */
     _dntTerms = [];
-
-    get dntTerms() {
-        return [...this._dntTerms];
-    }
 
     /**
      * @typedef ExplicitTerms
@@ -66,10 +63,10 @@ class ResourceDNTTerms extends Rule {
             // if the terms are not provided explicitly, parse them from a file
             switch (params.termsFileType) {
                 case "json":
-                    terms = ResourceDNTTerms._parseTermsFromJsonFile(params.termsFilePath);
+                    terms = ResourceDNTTerms.parseTermsFromJsonFile(params.termsFilePath);
                     break;
                 case "txt":
-                    terms = ResourceDNTTerms._parseTermsFromTxtFile(params.termsFilePath);
+                    terms = ResourceDNTTerms.parseTermsFromTxtFile(params.termsFilePath);
                     break;
                 default:
                     throw new Error(`"${params.termsFileType}" is not a valid DNT terms file type`);
@@ -132,7 +129,7 @@ class ResourceDNTTerms extends Rule {
     /** Parse DNT terms from a JSON `string[]` file
      * @param path Path to a DNT dictionary stored as JSON `string[]` file
      */
-    static _parseTermsFromJsonFile(/** @type {string} */ path) {
+    static parseTermsFromJsonFile(/** @type {string} */ path) {
         const text = fs.readFileSync(path, "utf8");
         let content = undefined;
         try {
@@ -146,10 +143,13 @@ class ResourceDNTTerms extends Rule {
         return /** @type {string[]} */ (content);
     }
 
-    /** Parse DNT terms from a text file by treating each line in file as a separate term */
-    static _parseTermsFromTxtFile(/** @type {string} */ path) {
+    /** Parse DNT terms from a text file by treating each line in file as a separate term
+     * 
+     * While parsing, it excludes empty lines and trims leading/trailing whitespace on each line
+     */
+    static parseTermsFromTxtFile(/** @type {string} */ path) {
         const text = fs.readFileSync(path, "utf8");
-        return text.split(/\r?\n/);
+        return text.split(/[\r\n]+/).map(line => line.trim()).filter(line => line.length > 0);
     }
 }
 

--- a/src/rules/ResourceDNTTerms.js
+++ b/src/rules/ResourceDNTTerms.js
@@ -103,7 +103,7 @@ class ResourceDNTTerms extends Rule {
             description: "A DNT term is missing in target string.",
         };
 
-        return this._matchResource(resource)?.map((partialResult) => new Result({ ...resultProps, ...partialResult }));
+        return this._matchResource(resource)?.map((partialResult) => new Result({ ...resultProps, ...partialResult })) ?? [];
     }
 
     _matchString(/** @type {string} */ source, /** @type {string} */ target) {

--- a/src/rules/ResourceDNTTerms.js
+++ b/src/rules/ResourceDNTTerms.js
@@ -33,37 +33,50 @@ class ResourceDNTTerms extends Rule {
      * @type {string[]}
      */
     _dntTerms = [];
-    
-    get dntTerms() { return this._dntTerms; }
 
-    constructor(
-        /** @type {{terms?: string[]; termsFilePath?: string; termsFileType?: ("json"|"txt")}} */ {
-            terms,
-            termsFilePath,
-            termsFileType = "json",
-        }
-    ) {
+    get dntTerms() {
+        return [...this._dntTerms];
+    }
+
+    /**
+     * @typedef ExplicitTerms
+     * @type {object}
+     * @property {string[]} terms Explicit list of DNT terms to check
+     */
+
+    /**
+     * @typedef FileTerms
+     * @type {object}
+     * @property {string} termsFilePath Path to DNT terms file (either absolute or relative to current working directory)
+     * @property {("json"|"txt")} termsFileType Determines how DNT file should be parsed - either as JSON or as TXT with one term per line
+     */
+
+    constructor(/** @type {ExplicitTerms | FileTerms} */ params) {
         super({});
+        let /** @type {string[]} */ terms = [];
 
-        if (undefined === terms) {
-            // if the terms are not provided explicitly, parse them from a file
-            if (undefined === termsFilePath) {
-                throw new Error("Neither DNT terms nor path to a DNT terms file were provided");
-            }
-            switch (termsFileType) {
-                case "json":
-                    terms = ResourceDNTTerms._parseTermsFromJsonFile(termsFilePath);
-                    break;
-                case "txt":
-                    terms = ResourceDNTTerms._parseTermsFromTxtFile(termsFilePath);
-                    break;
-                default:
-                    throw new Error(`"${termsFileType}" is not a valid DNT terms file type`);
-            }
-        } else {
+        if ("terms" in params) {
+            // explicit terms from config
+            terms = params.terms;
             // ensure valid type
             if (!Array.isArray(terms) || !terms.every((term) => "string" === typeof term)) {
                 throw new Error(`DNT terms provided in an unexpected format; expected string[]`);
+            }
+        } else {
+            // if the terms are not provided explicitly, parse them from a file
+            if ("string" !== typeof params.termsFilePath) {
+                throw new Error("Neither DNT terms nor path to a DNT terms file were provided");
+            }
+
+            switch (params.termsFileType) {
+                case "json":
+                    terms = ResourceDNTTerms._parseTermsFromJsonFile(params.termsFilePath);
+                    break;
+                case "txt":
+                    terms = ResourceDNTTerms._parseTermsFromTxtFile(params.termsFilePath);
+                    break;
+                default:
+                    throw new Error(`"${params.termsFileType}" is not a valid DNT terms file type`);
             }
         }
 

--- a/src/rules/ResourceDNTTerms.js
+++ b/src/rules/ResourceDNTTerms.js
@@ -20,6 +20,7 @@
 import { Rule, Result } from "i18nlint-common";
 import { Resource, ResourcePlural } from "ilib-tools-common";
 import fs from "node:fs";
+import path from "node:path";
 
 /** Rule to ensure that Do Not Translate terms have not been translated;
  * i.e., if a DNT term appears in source, it has to appear in target as well */
@@ -46,7 +47,7 @@ class ResourceDNTTerms extends Rule {
      * @typedef FileTerms
      * @type {object}
      * @property {string} termsFilePath Path to DNT terms file (either absolute or relative to current working directory)
-     * @property {("json"|"txt")} termsFileType Determines how DNT file should be parsed - either as JSON or as TXT with one term per line
+     * @property {("json"|"txt")} [termsFileType] Determines how DNT file should be parsed - either as JSON or as TXT with one term per line
      */
 
     constructor(/** @type {ExplicitTerms | FileTerms | {}} */ params) {
@@ -62,7 +63,8 @@ class ResourceDNTTerms extends Rule {
             }
         } else if ("termsFilePath" in params) {
             // if the terms are not provided explicitly, parse them from a file
-            switch (params.termsFileType) {
+            let termsFileType = params.termsFileType ?? path.extname(params.termsFilePath).slice(1).toLowerCase();
+            switch (termsFileType) {
                 case "json":
                     terms = ResourceDNTTerms.parseTermsFromJsonFile(params.termsFilePath);
                     break;
@@ -70,7 +72,7 @@ class ResourceDNTTerms extends Rule {
                     terms = ResourceDNTTerms.parseTermsFromTxtFile(params.termsFilePath);
                     break;
                 default:
-                    throw new Error(`"${params.termsFileType}" is not a valid DNT terms file type`);
+                    throw new Error(`"${termsFileType}" is not a valid DNT terms file type`);
             }
         } else {
             // no terms provided

--- a/src/rules/ResourceDNTTerms.js
+++ b/src/rules/ResourceDNTTerms.js
@@ -51,7 +51,7 @@ class ResourceDNTTerms extends Rule {
      * @property {("json"|"txt")} termsFileType Determines how DNT file should be parsed - either as JSON or as TXT with one term per line
      */
 
-    constructor(/** @type {ExplicitTerms | FileTerms} */ params) {
+    constructor(/** @type {ExplicitTerms | FileTerms | {}} */ params) {
         super({});
         let /** @type {string[]} */ terms = [];
 
@@ -62,12 +62,8 @@ class ResourceDNTTerms extends Rule {
             if (!Array.isArray(terms) || !terms.every((term) => "string" === typeof term)) {
                 throw new Error(`DNT terms provided in an unexpected format; expected string[]`);
             }
-        } else {
+        } else if ("termsFilePath" in params) {
             // if the terms are not provided explicitly, parse them from a file
-            if ("string" !== typeof params.termsFilePath) {
-                throw new Error("Neither DNT terms nor path to a DNT terms file were provided");
-            }
-
             switch (params.termsFileType) {
                 case "json":
                     terms = ResourceDNTTerms._parseTermsFromJsonFile(params.termsFilePath);
@@ -78,6 +74,9 @@ class ResourceDNTTerms extends Rule {
                 default:
                     throw new Error(`"${params.termsFileType}" is not a valid DNT terms file type`);
             }
+        } else {
+            // no terms provided
+            terms = [];
         }
 
         this._dntTerms = [...new Set(terms.filter((t) => t.length > 0))];

--- a/test/testRules.js
+++ b/test/testRules.js
@@ -1804,14 +1804,10 @@ export const testRules = {
     testResourceDNTTermsLoadTermsNotProvided: function(test) {
         test.expect(2);
 
-        try{
-            // @ts-ignore
-            new ResourceDNTTerms({});
-        } catch (e) {
-            test.ok(e instanceof Error);
-            test.equal(/** @type {Error} */ (e).message, "Neither DNT terms nor path to a DNT terms file were provided");
-        }
-
+        const rule = new ResourceDNTTerms({});
+        test.ok(rule);
+        test.deepEqual(rule.dntTerms, []);
+        
         test.done();
     },
 

--- a/test/testRules.js
+++ b/test/testRules.js
@@ -1717,6 +1717,122 @@ export const testRules = {
         test.done();
     },
 
+    testResourceDNTTermsMultiple: function(test) {
+        test.expect(2);
+
+        const rule = new ResourceDNTTerms({
+            terms: [
+                "Some DNT term",
+                "Another DNT term",
+                "Yet another DNT term",
+            ]
+        });
+        test.ok(rule);
+
+        const subject = {
+            locale: "de-DE",
+            file: "x/y",
+            resource: new ResourceString({
+                key: "resource-dnt-test.dnt-missing-multiple",
+                sourceLocale: "en-US",
+                source: "Some source string with Some DNT term and Another DNT term in it.",
+                targetLocale: "de-DE",
+                target: "Some target string with an incorrecly translated DNT term and another incorrecly translated DNT term in it.",
+                pathName: "dnt-test.xliff",
+                state: "translated",
+            }),
+        };
+
+        const result = rule.match(subject);
+        test.deepEqual(
+            result,
+            [
+                new Result({
+                    rule,
+                    severity: "error",
+                    pathName: "x/y",
+                    locale: "de-DE",
+                    source: "Some source string with Some DNT term and Another DNT term in it.",
+                    id: "resource-dnt-test.dnt-missing-multiple",
+                    description: "A DNT term is missing in target string.",
+                    highlight: `Missing term: <e0>Some DNT term</e0>`,
+                }),
+                new Result({
+                    rule,
+                    severity: "error",
+                    pathName: "x/y",
+                    locale: "de-DE",
+                    source: "Some source string with Some DNT term and Another DNT term in it.",
+                    id: "resource-dnt-test.dnt-missing-multiple",
+                    description: "A DNT term is missing in target string.",
+                    highlight: `Missing term: <e0>Another DNT term</e0>`,
+                })
+            ]
+        );
+        test.done();
+    },
+
+    testResourceDNTTermsOk: function(test) {
+        test.expect(2);
+
+        const rule = new ResourceDNTTerms({
+            terms: [
+                "Some DNT term"
+            ]
+        });
+        test.ok(rule);
+
+        const subject = {
+            locale: "de-DE",
+            file: "x/y",
+            resource: new ResourceString({
+                key: "resource-dnt-test.dnt-ok",
+                sourceLocale: "en-US",
+                source: "Some source string with Some DNT term in it.",
+                targetLocale: "de-DE",
+                target: "Some target string with Some DNT term in it.",
+                pathName: "dnt-test.xliff",
+                state: "translated",
+            }),
+        };
+
+        const result = rule.match(subject);
+        test.deepEqual(result, []);
+        test.done();
+    },
+
+    testResourceDNTTermsLoadTermsNotProvided: function(test) {
+        test.expect(2);
+
+        try{
+            new ResourceDNTTerms({});
+        } catch (e) {
+            test.ok(e instanceof Error);
+            test.equal(/** @type {Error} */ (e).message, "Neither DNT terms nor path to a DNT terms file were provided");
+        }
+
+        test.done();
+    },
+
+    testResourceDNTTermsLoadTermsFromConfig: function(test) {
+        test.expect(2);
+
+        const rule = new ResourceDNTTerms({
+            terms: [
+                "Some DNT term",
+                "Another DNT term"
+            ]
+        });
+        test.ok(rule);
+
+        test.deepEqual(rule.dntTerms, [
+            "Some DNT term",
+            "Another DNT term"
+        ]);
+
+        test.done();
+    },
+    
     testResourceDNTTermsLoadTermsFromJSONFile: function(test) {
         test.expect(2);
 

--- a/test/testRules.js
+++ b/test/testRules.js
@@ -1723,7 +1723,6 @@ export const testRules = {
         // "Some DNT term" from TXT file should be matched
 
         const rule = new ResourceDNTTerms({
-            termsFileType: "txt",
             termsFilePath: "./test/testfiles/dnt-test.txt",
         });
         test.ok(rule);
@@ -1765,7 +1764,6 @@ export const testRules = {
         // "Some DNT term" from JSON file should be matched
 
         const rule = new ResourceDNTTerms({
-            termsFileType: "json",
             termsFilePath: "./test/testfiles/dnt-test.json",
         });
         test.ok(rule);

--- a/test/testRules.js
+++ b/test/testRules.js
@@ -2153,7 +2153,7 @@ export const testRules = {
             "Some DNT term",
             "Another DNT term",
             "A DNT term that should be trimmed",
-            "Yet another DNT temr that should be trimmed",
+            "Yet another DNT term that should be trimmed",
             "A DNT term after an empty line",
         ]);
 

--- a/test/testRules.js
+++ b/test/testRules.js
@@ -16,7 +16,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ResourceString } from 'ilib-tools-common';
+import { ResourceArray, ResourcePlural, ResourceString } from 'ilib-tools-common';
 
 import ResourceQuoteStyle from '../src/rules/ResourceQuoteStyle.js';
 import ResourceICUPlurals from '../src/rules/ResourceICUPlurals.js';
@@ -1852,6 +1852,97 @@ export const testRules = {
                     highlight: `Missing term: <e0>Another DNT term</e0>`,
                 })
             ]
+        );
+        test.done();
+    },
+
+    testResourceDNTTermsResourceArray: function(test) {
+        test.expect(2);
+
+        const rule = new ResourceDNTTerms({
+            terms: [
+                "Some DNT term",
+                "Another DNT term"
+            ]
+        });
+        test.ok(rule);
+
+        const subject = {
+            locale: "de-DE",
+            file: "x/y",
+            resource: new ResourceArray({
+                key: "resource-dnt-test.dnt-missing-resource-array",
+                sourceLocale: "en-US",
+                source: ["not a DNT term item", "Some DNT term item"],
+                targetLocale: "de-DE",
+                target: ["translated term item", "incorrecly translated DNT term item"],
+                pathName: "dnt-test.xliff",
+                state: "translated",
+            }),
+        };
+
+        const result = rule.match(subject);
+        test.deepEqual(
+            result,
+            [new Result({
+                rule,
+                severity: "error",
+                pathName: "x/y",
+                locale: "de-DE",
+                source: "Some DNT term item",
+                id: "resource-dnt-test.dnt-missing-resource-array",
+                description: "A DNT term is missing in target string.",
+                highlight: `Missing term: <e0>Some DNT term</e0>`,
+            })]
+        );
+        test.done();
+    },
+
+    testResourceDNTTermsResourcePlural: function(test) {
+        test.expect(2);
+
+        const rule = new ResourceDNTTerms({
+            terms: [
+                "Some DNT term",
+                "Another DNT term"
+            ]
+        });
+        test.ok(rule);
+
+        const subject = {
+            locale: "de-DE",
+            file: "x/y",
+            resource: new ResourcePlural({
+                key: "resource-dnt-test.dnt-missing-resource-plural",
+                sourceLocale: "en-US",
+                source: {
+                    "one": "This is Some DNT term singular",
+                    "many": "This is Some DNT term many"
+                },
+                targetLocale: "de-DE",
+                target: {
+                    "one": "This is incorrectly translated DNT term singular",
+                    "two": "This is incorrectly translated DNT term double",
+                    "many": "This is translated Some DNT term many"
+                },
+                pathName: "dnt-test.xliff",
+                state: "translated",
+            }),
+        };
+
+        const result = rule.match(subject);
+        test.deepEqual(
+            result,
+            [new Result({
+                rule,
+                severity: "error",
+                pathName: "x/y",
+                locale: "de-DE",
+                source: "This is Some DNT term singular",
+                id: "resource-dnt-test.dnt-missing-resource-plural",
+                description: "A DNT term is missing in target string.",
+                highlight: `Missing term: <e0>Some DNT term</e0>`,
+            })]
         );
         test.done();
     },

--- a/test/testRules.js
+++ b/test/testRules.js
@@ -1805,6 +1805,7 @@ export const testRules = {
         test.expect(2);
 
         try{
+            // @ts-ignore
             new ResourceDNTTerms({});
         } catch (e) {
             test.ok(e instanceof Error);

--- a/test/testRules.js
+++ b/test/testRules.js
@@ -1897,7 +1897,7 @@ export const testRules = {
         test.done();
     },
 
-    testResourceDNTTermsResourcePlural: function(test) {
+    testResourceDNTTermsResourcePluralAllCategories: function(test) {
         test.expect(2);
 
         const rule = new ResourceDNTTerms({
@@ -1912,7 +1912,7 @@ export const testRules = {
             locale: "de-DE",
             file: "x/y",
             resource: new ResourcePlural({
-                key: "resource-dnt-test.dnt-missing-resource-plural",
+                key: "resource-dnt-test.dnt-missing-resource-plural-all-categories",
                 sourceLocale: "en-US",
                 source: {
                     "one": "This is Some DNT term singular",
@@ -1922,7 +1922,7 @@ export const testRules = {
                 target: {
                     "one": "This is incorrectly translated DNT term singular",
                     "two": "This is incorrectly translated DNT term double",
-                    "many": "This is translated Some DNT term many"
+                    "many": "This is correctly translated Some DNT term many"
                 },
                 pathName: "dnt-test.xliff",
                 state: "translated",
@@ -1930,19 +1930,76 @@ export const testRules = {
         };
 
         const result = rule.match(subject);
-        test.deepEqual(
-            result,
-            [new Result({
+        test.deepEqual(result, [
+            new Result({
                 rule,
                 severity: "error",
                 pathName: "x/y",
                 locale: "de-DE",
                 source: "This is Some DNT term singular",
-                id: "resource-dnt-test.dnt-missing-resource-plural",
+                id: "resource-dnt-test.dnt-missing-resource-plural-all-categories",
                 description: "A DNT term is missing in target string.",
                 highlight: `Missing term: <e0>Some DNT term</e0>`,
-            })]
-        );
+            }),
+            new Result({
+                rule,
+                severity: "error",
+                pathName: "x/y",
+                locale: "de-DE",
+                source: undefined, // no category `two` defined in source
+                id: "resource-dnt-test.dnt-missing-resource-plural-all-categories",
+                description: "A DNT term is missing in target string.",
+                highlight: `Missing term: <e0>Some DNT term</e0>`,
+            }),
+        ]);
+        test.done();
+    },
+
+    testResourceDNTTermsResourcePluralSomeCategories: function(test) {
+        test.expect(2);
+
+        const rule = new ResourceDNTTerms({
+            terms: [
+                "Some DNT term",
+                "Another DNT term"
+            ]
+        });
+        test.ok(rule);
+
+        const subject = {
+            locale: "de-DE",
+            file: "x/y",
+            resource: new ResourcePlural({
+                key: "resource-dnt-test.dnt-missing-resource-plural-some-categories",
+                sourceLocale: "en-US",
+                source: {
+                    "one": "This is Some DNT term singular",
+                    "many": "This is not a DNT term many"
+                },
+                targetLocale: "de-DE",
+                target: {
+                    "one": "This is incorrectly translated DNT term singular",
+                    "two": "This is incorrectly translated DNT term double",
+                    "many": "This is correctly translated Some DNT term many"
+                },
+                pathName: "dnt-test.xliff",
+                state: "translated",
+            }),
+        };
+
+        const result = rule.match(subject);
+        test.deepEqual(result, [
+            new Result({
+                rule,
+                severity: "error",
+                pathName: "x/y",
+                locale: "de-DE",
+                source: "This is Some DNT term singular",
+                id: "resource-dnt-test.dnt-missing-resource-plural-some-categories",
+                description: "A DNT term is missing in target string.",
+                highlight: `Missing term: <e0>Some DNT term</e0>`,
+            })
+        ]);
         test.done();
     },
 
@@ -2004,7 +2061,7 @@ export const testRules = {
         test.done();
     },
 
-    testResourceDNTTermsOkPlural: function(test) {
+    testResourceDNTTermsOkPluralAllCategories: function(test) {
         test.expect(2);
 
         const rule = new ResourceDNTTerms({
@@ -2018,7 +2075,7 @@ export const testRules = {
             locale: "de-DE",
             file: "x/y",
             resource: new ResourcePlural({
-                key: "resource-dnt-test.dnt-missing-resource-plural",
+                key: "resource-dnt-test.dnt-ok-resource-plural-all-categories",
                 sourceLocale: "en-US",
                 source: {
                     "one": "This is Some DNT term singular",
@@ -2029,6 +2086,42 @@ export const testRules = {
                     "one": "This is correctly translated Some DNT term singular",
                     "two": "This is correctly translated Some DNT term double",
                     "many": "This is correctly translated Some DNT term many"
+                },
+                pathName: "dnt-test.xliff",
+                state: "translated",
+            }),
+        };
+
+        const result = rule.match(subject);
+        test.deepEqual(result, []);
+        test.done();
+    },
+
+    testResourceDNTTermsOkPluralSomeCategories: function(test) {
+        test.expect(2);
+
+        const rule = new ResourceDNTTerms({
+            terms: [
+                "Some DNT term"
+            ]
+        });
+        test.ok(rule);
+
+        const subject = {
+            locale: "de-DE",
+            file: "x/y",
+            resource: new ResourcePlural({
+                key: "resource-dnt-test.dnt-ok-resource-plural-some-categories",
+                sourceLocale: "en-US",
+                source: {
+                    "one": "This is Some DNT term singular",
+                    "many": "This is not a DNT term many"
+                },
+                targetLocale: "de-DE",
+                target: {
+                    "one": "This is correctly translated Some DNT term singular",
+                    "two": "This is correctly translated not a DNT term double",
+                    "many": "This is correctly translated not a DNT term many"
                 },
                 pathName: "dnt-test.xliff",
                 state: "translated",

--- a/test/testRules.js
+++ b/test/testRules.js
@@ -23,6 +23,7 @@ import ResourceICUPlurals from '../src/rules/ResourceICUPlurals.js';
 import ResourceStateChecker from '../src/rules/ResourceStateChecker.js';
 import ResourceEdgeWhitespace from '../src/rules/ResourceEdgeWhitespace.js';
 import ResourceCompleteness from "../src/rules/ResourceCompleteness.js";
+import ResourceDNTTerms from '../src/rules/ResourceDNTTerms.js';
 
 import { Result } from 'i18nlint-common';
 
@@ -1673,6 +1674,47 @@ export const testRules = {
         // (it can be ommited for those resources where target is equal to source)
         test.equal(result, undefined);
         test.done()
+    },
+
+    testResourceDNTTerms: function(test) {
+        test.expect(2);
+
+        const rule = new ResourceDNTTerms({
+            terms: [
+                "Some DNT term"
+            ]
+        });
+        test.ok(rule);
+
+        const subject = {
+            locale: "de-DE",
+            file: "x/y",
+            resource: new ResourceString({
+                key: "resource-dnt-test.dnt-missing",
+                sourceLocale: "en-US",
+                source: "Some source string with Some DNT term in it.",
+                targetLocale: "de-DE",
+                target: "Some target string with an incorrecly translated DNT term in it.",
+                pathName: "dnt-test.xliff",
+                state: "translated",
+            }),
+        };
+
+        const result = rule.match(subject);
+        test.deepEqual(
+            result,
+            [new Result({
+                rule,
+                severity: "error",
+                pathName: "x/y",
+                locale: "de-DE",
+                source: "Some source string with Some DNT term in it.",
+                id: "resource-dnt-test.dnt-missing",
+                description: "A DNT term is missing in target string.",
+                highlight: `Missing term: <e0>Some DNT term</e0>`,
+            })]
+        );
+        test.done();
     },
 };
 

--- a/test/testRules.js
+++ b/test/testRules.js
@@ -1716,5 +1716,39 @@ export const testRules = {
         );
         test.done();
     },
+
+    testResourceDNTTermsLoadTermsFromJSONFile: function(test) {
+        test.expect(2);
+
+        const rule = new ResourceDNTTerms({
+            termsFileType: "json",
+            termsFilePath: "./test/testfiles/dnt-test.json"
+        });
+        test.ok(rule);
+
+        test.deepEqual(rule.dntTerms, [
+            "Some DNT term",
+            "Another DNT term"
+        ]);
+
+        test.done();
+    },
+
+    testResourceDNTTermsLoadTermsFromTxtFile: function(test) {
+        test.expect(2);
+
+        const rule = new ResourceDNTTerms({
+            termsFileType: "txt",
+            termsFilePath: "./test/testfiles/dnt-test.txt"
+        });
+        test.ok(rule);
+
+        test.deepEqual(rule.dntTerms, [
+            "Some DNT term",
+            "Another DNT term"
+        ]);
+
+        test.done();
+    },
 };
 

--- a/test/testRules.js
+++ b/test/testRules.js
@@ -1717,6 +1717,90 @@ export const testRules = {
         test.done();
     },
 
+    testResourceDNTTermsWithTermsFromTxtFile: function(test) {
+        test.expect(2);
+
+        // "Some DNT term" from TXT file should be matched
+
+        const rule = new ResourceDNTTerms({
+            termsFileType: "txt",
+            termsFilePath: "./test/testfiles/dnt-test.txt",
+        });
+        test.ok(rule);
+
+        const subject = {
+            locale: "de-DE",
+            file: "x/y",
+            resource: new ResourceString({
+                key: "resource-dnt-test.dnt-terms-from-txt",
+                sourceLocale: "en-US",
+                source: "Some source string with Some DNT term in it.",
+                targetLocale: "de-DE",
+                target: "Some target string with an incorrecly translated DNT term in it.",
+                pathName: "dnt-test.xliff",
+                state: "translated",
+            }),
+        };
+
+        const result = rule.match(subject);
+        test.deepEqual(
+            result,
+            [new Result({
+                rule,
+                severity: "error",
+                pathName: "x/y",
+                locale: "de-DE",
+                source: "Some source string with Some DNT term in it.",
+                id: "resource-dnt-test.dnt-terms-from-txt",
+                description: "A DNT term is missing in target string.",
+                highlight: `Missing term: <e0>Some DNT term</e0>`,
+            })]
+        );
+        test.done();
+    },
+
+    testResourceDNTTermsWithTermsFromJsonFile: function(test) {
+        test.expect(2);
+
+        // "Some DNT term" from JSON file should be matched
+
+        const rule = new ResourceDNTTerms({
+            termsFileType: "json",
+            termsFilePath: "./test/testfiles/dnt-test.json",
+        });
+        test.ok(rule);
+
+        const subject = {
+            locale: "de-DE",
+            file: "x/y",
+            resource: new ResourceString({
+                key: "resource-dnt-test.dnt-terms-from-json",
+                sourceLocale: "en-US",
+                source: "Some source string with Some DNT term in it.",
+                targetLocale: "de-DE",
+                target: "Some target string with an incorrecly translated DNT term in it.",
+                pathName: "dnt-test.xliff",
+                state: "translated",
+            }),
+        };
+
+        const result = rule.match(subject);
+        test.deepEqual(
+            result,
+            [new Result({
+                rule,
+                severity: "error",
+                pathName: "x/y",
+                locale: "de-DE",
+                source: "Some source string with Some DNT term in it.",
+                id: "resource-dnt-test.dnt-terms-from-json",
+                description: "A DNT term is missing in target string.",
+                highlight: `Missing term: <e0>Some DNT term</e0>`,
+            })]
+        );
+        test.done();
+    },
+
     testResourceDNTTermsMultiple: function(test) {
         test.expect(2);
 
@@ -1800,46 +1884,13 @@ export const testRules = {
         test.deepEqual(result, []);
         test.done();
     },
-
-    testResourceDNTTermsLoadTermsNotProvided: function(test) {
-        test.expect(2);
-
-        const rule = new ResourceDNTTerms({});
-        test.ok(rule);
-        test.deepEqual(rule.dntTerms, []);
-        
-        test.done();
-    },
-
-    testResourceDNTTermsLoadTermsFromConfig: function(test) {
-        test.expect(2);
-
-        const rule = new ResourceDNTTerms({
-            terms: [
-                "Some DNT term",
-                "Another DNT term"
-            ]
-        });
-        test.ok(rule);
-
-        test.deepEqual(rule.dntTerms, [
-            "Some DNT term",
-            "Another DNT term"
-        ]);
-
-        test.done();
-    },
     
-    testResourceDNTTermsLoadTermsFromJSONFile: function(test) {
-        test.expect(2);
+    testResourceDNTTermsParseTermsFromJSONFile: function(test) {
+        test.expect(1);
 
-        const rule = new ResourceDNTTerms({
-            termsFileType: "json",
-            termsFilePath: "./test/testfiles/dnt-test.json"
-        });
-        test.ok(rule);
+        const terms = ResourceDNTTerms.parseTermsFromJsonFile("./test/testfiles/dnt-test.json");
 
-        test.deepEqual(rule.dntTerms, [
+        test.deepEqual(terms, [
             "Some DNT term",
             "Another DNT term"
         ]);
@@ -1847,18 +1898,17 @@ export const testRules = {
         test.done();
     },
 
-    testResourceDNTTermsLoadTermsFromTxtFile: function(test) {
-        test.expect(2);
+    testResourceDNTTermsParseTermsFromTxtFile: function(test) {
+        test.expect(1);
 
-        const rule = new ResourceDNTTerms({
-            termsFileType: "txt",
-            termsFilePath: "./test/testfiles/dnt-test.txt"
-        });
-        test.ok(rule);
+        const terms = ResourceDNTTerms.parseTermsFromTxtFile("./test/testfiles/dnt-test.txt");
 
-        test.deepEqual(rule.dntTerms, [
+        test.deepEqual(terms, [
             "Some DNT term",
-            "Another DNT term"
+            "Another DNT term",
+            "A DNT term that should be trimmed",
+            "Yet another DNT temr that should be trimmed",
+            "A DNT term after an empty line",
         ]);
 
         test.done();

--- a/test/testRules.js
+++ b/test/testRules.js
@@ -1861,8 +1861,7 @@ export const testRules = {
 
         const rule = new ResourceDNTTerms({
             terms: [
-                "Some DNT term",
-                "Another DNT term"
+                "Some DNT term"
             ]
         });
         test.ok(rule);
@@ -1966,6 +1965,71 @@ export const testRules = {
                 source: "Some source string with Some DNT term in it.",
                 targetLocale: "de-DE",
                 target: "Some target string with Some DNT term in it.",
+                pathName: "dnt-test.xliff",
+                state: "translated",
+            }),
+        };
+
+        const result = rule.match(subject);
+        test.deepEqual(result, []);
+        test.done();
+    },
+
+    testResourceDNTTermsOkArray: function(test) {
+        test.expect(2);
+
+        const rule = new ResourceDNTTerms({
+            terms: [
+                "Some DNT term"
+            ]
+        });
+        test.ok(rule);
+
+        const subject = {
+            locale: "de-DE",
+            file: "x/y",
+            resource: new ResourceArray({
+                key: "resource-dnt-test.dnt-ok-resource-array",
+                sourceLocale: "en-US",
+                source: ["not a DNT term item", "Some DNT term item"],
+                targetLocale: "de-DE",
+                target: ["translated term item", "correctly translated Some DNT term item"],
+                pathName: "dnt-test.xliff",
+                state: "translated",
+            }),
+        };
+
+        const result = rule.match(subject);
+        test.deepEqual(result, []);
+        test.done();
+    },
+
+    testResourceDNTTermsOkPlural: function(test) {
+        test.expect(2);
+
+        const rule = new ResourceDNTTerms({
+            terms: [
+                "Some DNT term"
+            ]
+        });
+        test.ok(rule);
+
+        const subject = {
+            locale: "de-DE",
+            file: "x/y",
+            resource: new ResourcePlural({
+                key: "resource-dnt-test.dnt-missing-resource-plural",
+                sourceLocale: "en-US",
+                source: {
+                    "one": "This is Some DNT term singular",
+                    "many": "This is Some DNT term many"
+                },
+                targetLocale: "de-DE",
+                target: {
+                    "one": "This is correctly translated Some DNT term singular",
+                    "two": "This is correctly translated Some DNT term double",
+                    "many": "This is correctly translated Some DNT term many"
+                },
                 pathName: "dnt-test.xliff",
                 state: "translated",
             }),

--- a/test/testfiles/dnt-test.json
+++ b/test/testfiles/dnt-test.json
@@ -1,0 +1,4 @@
+[
+    "Some DNT term",
+    "Another DNT term"
+]

--- a/test/testfiles/dnt-test.txt
+++ b/test/testfiles/dnt-test.txt
@@ -1,6 +1,6 @@
 Some DNT term
 Another DNT term
     A DNT term that should be trimmed
-Yet another DNT temr that should be trimmed 
+Yet another DNT term that should be trimmed 
 
 A DNT term after an empty line

--- a/test/testfiles/dnt-test.txt
+++ b/test/testfiles/dnt-test.txt
@@ -1,0 +1,2 @@
+Some DNT term
+Another DNT term

--- a/test/testfiles/dnt-test.txt
+++ b/test/testfiles/dnt-test.txt
@@ -1,2 +1,6 @@
 Some DNT term
 Another DNT term
+    A DNT term that should be trimmed
+Yet another DNT temr that should be trimmed 
+
+A DNT term after an empty line


### PR DESCRIPTION
Create a rule that checks if the term exists in the source and if so, the same term appears somewhere in the target.