### PR TITLE
Refactored declarative and resource rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -723,8 +723,9 @@ limitations under the License.
 
 ### v1.6.1
 
-- Having no state attribute on the target tag of a translation unit would
+- having no state attribute on the target tag of a translation unit would
   cause an exception. Now it properly gives an error that no state was found.
+- fixed a problem where the same results were printed out multiple times
 
 ### v1.6.0
 

--- a/src/RuleManager.js
+++ b/src/RuleManager.js
@@ -103,11 +103,25 @@ class RuleManager {
     }
 
     /**
+     * Recursively look up the inheritance tree to see if this rule eventually
+     * inherited from the Rule class somewhere along the way. We finish looking
+     * if we get to the top-level "Object" class and we didn't find any
+     * Rule class.
+     * @private
+     */
+    inheritsFromRule(object) {
+        const proto = Object.getPrototypeOf(object);
+        if (proto.name === "Rule") return true;
+        if (proto.name === "Object") return false;
+        return this.inheritsFromRule(proto);
+    }
+
+    /**
      * @private
      */
     addRule(rule) {
         if (rule) {
-            if (typeof(rule) === 'function' && Object.getPrototypeOf(rule).name === "Rule") {
+            if (typeof(rule) === 'function' && this.inheritsFromRule(rule)) {
                 const p = new rule({
                     sourceLocale: this.sourceLocale,
                     getLogger: log4js.getLogger.bind(log4js)

--- a/src/SourceFile.js
+++ b/src/SourceFile.js
@@ -27,6 +27,10 @@ import DirItem from './DirItem.js';
 
 const logger = log4js.getLogger("i18nlint.RuleSet");
 
+/**
+ * If it's not already an array, make it an array!
+ * @private
+ */
 function makeArray(obj) {
     if (!obj) return [];
     if (Array.isArray(obj)) return obj;
@@ -129,40 +133,12 @@ class SourceFile extends DirItem {
             // find the rules that are appropriate for this intermediate representation and then apply them
             const rules = this.filetype.getRules().filter(rule => (rule.getRuleType() === ir.getType()));
             rules.forEach(rule => {
-                const representation = ir.getRepresentation();
-                switch (ir.getType()) {
-                case "line":
-                    for (let i = 0; i < representation.length; i++) {
-                        result = rule.match({
-                            ir,
-                            line: representation[i],
-                            locale: detectedLocale || this.project.getSourceLocale(),
-                            file: ir.getFilePath()
-                        });
-                        if (result) issues = issues.concat(makeArray(result));
-                    }
-                    break;
-                case "resource":
-                    representation.forEach(resource => {
-                        logger.trace(`Applying rule ${rule.getName()} to resource ${resource.reskey}`);
-                        result = rule.match({
-                            ir,
-                            locale: resource.getTargetLocale(),
-                            resource,
-                            file: this.filePath
-                        });
-                        if (result) issues = issues.concat(makeArray(result));
-                    });
-                    break;
-                default:
-                    // all other cases -- don't iterate, just call the rule
-                    // with the whole intermediate representation
-                    result = rule.match({
-                        ir,
-                        locale: detectedLocale || this.project.getSourceLocale()
-                    });
-                    if (result) issues = issues.concat(makeArray(result));
-                }
+                result = rule.match({
+                    ir,
+                    locale: detectedLocale || this.project.getSourceLocale(),
+                    file: this.filePath
+                });
+                if (result) issues = issues.concat(makeArray(result));
             });
         });
 

--- a/src/rules/DeclarativeResourceRule.js
+++ b/src/rules/DeclarativeResourceRule.js
@@ -1,0 +1,69 @@
+/*
+ * DeclarativeResourceRule.js - subclass of ResourceRule that can iterate over
+ * an arrays of regular expressions to apply to a resource 
+ *
+ * Copyright © 2023 JEDLSoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import ResourceRule from './ResourceRule.js';
+
+class DeclarativeResourceRule extends ResourceRule {
+    /**
+     * Construct a new regular expression-based declarative resource rule.
+     *
+     * @param {Object} options options as documented above
+     * @constructor
+     */
+    constructor(options) {
+        super(options);
+
+        if (!options || !options.regexps) {
+            throw "Missing required options for the DeclarativeResourceRule constructor";
+        }
+        this.regexps = options?.regexps;
+
+        // this may throw if you got to the regexp syntax wrong:
+        this.re = this.regexps.map(regexp => new RegExp(regexp, "gu"));
+    }
+
+    /**
+     * Check a specific source/target pair for a match with the given regular expression.
+     *
+     * @abstract
+     * @param {RegExp} re the regular expression to match
+     * @param {String|undefined} source the source string to match against
+     * @param {String|undefined} target the target string to match against
+     * @param {String} file path to the file where this resource was found
+     * @param {Resource} resource the resource where this pair of strings is from
+     * @returns {Result|Array.<Result>|undefined} the Result objects detailing
+     * any matches to the regular expression
+     */
+    checkString(re, source, target, file, resource) {}
+
+    /**
+     * @override
+     */
+    matchString(locale, source, target, file, resource) {
+        let results = [];
+        this.re.forEach(re => {
+            results = results.concat(this.checkString(re, source, target, file, resource));
+        });
+        results = results.filter(result => result);
+        return results && results.length ? results : undefined;
+    }
+}
+
+export default DeclarativeResourceRule;

--- a/src/rules/DeclarativeResourceRule.js
+++ b/src/rules/DeclarativeResourceRule.js
@@ -24,6 +24,12 @@ class DeclarativeResourceRule extends ResourceRule {
     /**
      * Construct a new regular expression-based declarative resource rule.
      *
+     * In addition to the options required by the ResourceRule class, the
+     * options must contain the following required properties:
+     *
+     * - regexps - an array of strings that encode regular expressions to
+     *   look for
+     *
      * @param {Object} options options as documented above
      * @constructor
      */
@@ -33,33 +39,35 @@ class DeclarativeResourceRule extends ResourceRule {
         if (!options || !options.regexps) {
             throw "Missing required options for the DeclarativeResourceRule constructor";
         }
-        this.regexps = options?.regexps;
 
         // this may throw if you got to the regexp syntax wrong:
-        this.re = this.regexps.map(regexp => new RegExp(regexp, "gu"));
+        this.re = options.regexps.map(regexp => new RegExp(regexp, "gu"));
     }
 
     /**
      * Check a specific source/target pair for a match with the given regular expression.
      *
+     * The params object will contain the following properties:
+     *
+     * - {RegExp} re the regular expression to match
+     * - {String|undefined} source the source string to match against
+     * - {String|undefined} target the target string to match against
+     * - {String} file path to the file where this resource was found
+     * - {Resource} resource the resource where this pair of strings is from
+     *
      * @abstract
-     * @param {RegExp} re the regular expression to match
-     * @param {String|undefined} source the source string to match against
-     * @param {String|undefined} target the target string to match against
-     * @param {String} file path to the file where this resource was found
-     * @param {Resource} resource the resource where this pair of strings is from
      * @returns {Result|Array.<Result>|undefined} the Result objects detailing
      * any matches to the regular expression
      */
-    checkString(re, source, target, file, resource) {}
+    checkString(params) {}
 
     /**
      * @override
      */
-    matchString(locale, source, target, file, resource) {
+    matchString({source, target, file, resource}) {
         let results = [];
         this.re.forEach(re => {
-            results = results.concat(this.checkString(re, source, target, file, resource));
+            results = results.concat(this.checkString({re, source, target, file, resource}));
         });
         results = results.filter(result => result);
         return results && results.length ? results : undefined;

--- a/src/rules/DeclarativeResourceRule.js
+++ b/src/rules/DeclarativeResourceRule.js
@@ -53,15 +53,12 @@ class DeclarativeResourceRule extends ResourceRule {
     /**
      * Check a specific source/target pair for a match with the given regular expression.
      *
-     * The params object will contain the following properties:
-     *
-     * - {RegExp} re the regular expression to match
-     * - {String|undefined} source the source string to match against
-     * - {String|undefined} target the target string to match against
-     * - {String} file path to the file where this resource was found
-     * - {Resource} resource the resource where this pair of strings is from
-     *
      * @abstract
+     * @param {RegExp} params.re the regular expression to match
+     * @param {String|undefined} params.source the source string to match against
+     * @param {String|undefined} params.target the target string to match against
+     * @param {String} params.file path to the file where this resource was found
+     * @param {Resource} params.resource the resource where this pair of strings is from
      * @returns {Result|Array.<Result>|undefined} the Result objects detailing
      * any matches to the regular expression
      */

--- a/src/rules/DeclarativeResourceRule.js
+++ b/src/rules/DeclarativeResourceRule.js
@@ -36,9 +36,15 @@ class DeclarativeResourceRule extends ResourceRule {
     constructor(options) {
         super(options);
 
-        if (!options || !options.regexps) {
+        if (!options || !options.name || !options.description || !options.note || !options.regexps) {
             throw "Missing required options for the DeclarativeResourceRule constructor";
         }
+
+        ["name", "description", "note", "sourceLocale", "link", "severity"].forEach(prop => {
+            this[prop] = options[prop];
+        });
+        this.sourceLocale = this.sourceLocale || "en-US";
+        this.severity = this.severity || "error";
 
         // this may throw if you got to the regexp syntax wrong:
         this.re = options.regexps.map(regexp => new RegExp(regexp, "gu"));

--- a/src/rules/DeclarativeResourceRule.js
+++ b/src/rules/DeclarativeResourceRule.js
@@ -1,6 +1,6 @@
 /*
  * DeclarativeResourceRule.js - subclass of ResourceRule that can iterate over
- * an arrays of regular expressions to apply to a resource 
+ * an arrays of regular expressions to apply to a resource
  *
  * Copyright © 2023 JEDLSoft
  *

--- a/src/rules/DeclarativeResourceRule.js
+++ b/src/rules/DeclarativeResourceRule.js
@@ -54,6 +54,7 @@ class DeclarativeResourceRule extends ResourceRule {
      * Check a specific source/target pair for a match with the given regular expression.
      *
      * @abstract
+     * @param {Object} params a parameters object
      * @param {RegExp} params.re the regular expression to match
      * @param {String|undefined} params.source the source string to match against
      * @param {String|undefined} params.target the target string to match against

--- a/src/rules/LineRegexpChecker.js
+++ b/src/rules/LineRegexpChecker.js
@@ -135,6 +135,7 @@ class LineRegexpChecker extends Rule {
         if (!ir || ir.getType() !== "line") return;
 
         let results = [];
+
         // representation should be an array of lines 
         const lines = ir.getRepresentation();
 

--- a/src/rules/ResourceCompleteness.js
+++ b/src/rules/ResourceCompleteness.js
@@ -35,10 +35,11 @@ class ResourceCompleteness extends ResourceRule {
     /**
      * Check that a given resource has both source and target tags set
      * @override
-     * @param {string} source the source string
-     * @param {string} target the target string
-     * @param {import("ilib-tools-common").Resource} resource the resource being checked
-     * @param {string} file the file where the resource came from
+     * @param {Object} params a parameters object
+     * @param {string} params.source the source string
+     * @param {string} params.target the target string
+     * @param {import("ilib-tools-common").Resource} params.resource the resource being checked
+     * @param {string} params.file the file where the resource came from
      * @returns {Array.<Result>|undefined} the results
      */
     matchString({ source, target, resource, file }) {

--- a/src/rules/ResourceCompleteness.js
+++ b/src/rules/ResourceCompleteness.js
@@ -17,37 +17,31 @@
  * limitations under the License.
  */
 
-import { Rule, Result } from "i18nlint-common";
+import { Result } from "i18nlint-common";
 import Locale from "ilib-locale";
 
+import ResourceRule from './ResourceRule.js';
+
 /** Rule to check that a resource has both source and target elements */
-class ResourceCompleteness extends Rule {
+class ResourceCompleteness extends ResourceRule {
     /** @readonly */ name = "resource-completeness";
     /** @readonly */ description = "Ensure that resources are complete, i.e. have both source and target elements.";
     /** @readonly */ link = "https://github.com/ilib-js/i18nlint/blob/main/docs/resource-completeness.md";
-    /** @readonly */ ruleType = "resource";
 
-    constructor() {
-        super({});
+    constructor(options) {
+        super(options);
     }
 
-    /** @override */
-    getRuleType() {
-        return this.ruleType;
-    }
-
-    /** Check that a given resource has both source and target tags set
+    /**
+     * Check that a given resource has both source and target tags set
      * @override
-     * @param {object} options
-     * @param {import("ilib-tools-common").Resource} options.resource
-     * @param {string} options.file
-     * @param {string} options.locale
-     *
+     * @param {string} source the source string
+     * @param {string} target the target string
+     * @param {import("ilib-tools-common").Resource} resource the resource being checked
+     * @param {string} file the file where the resource came from
+     * @returns {Array.<Result>|undefined} the results
      */
-    match({ resource, file, locale }) {
-        const source = resource.getSource();
-        const target = resource.getTarget();
-
+    matchString({ source, target, resource, file }) {
         // note: language specifiers for comparison - "en-US" should match "en-GB" (same language, only different region)
         const sourceLangSpec = new Locale(resource.sourceLocale).getLangSpec();
         const targetLangSpec = new Locale(resource.targetLocale).getLangSpec();
@@ -57,7 +51,7 @@ class ResourceCompleteness extends Rule {
             rule: this,
             pathName: file,
             source,
-            locale,
+            locale: resource.getTargetLocale()
         };
 
         // for each source string, a translation must be provided

--- a/src/rules/ResourceEdgeWhitespace.js
+++ b/src/rules/ResourceEdgeWhitespace.js
@@ -17,36 +17,24 @@
  * limitations under the License.
  */
 
-import { Rule, Result, withVisibleWhitespace } from "i18nlint-common";
+import { Result, withVisibleWhitespace } from "i18nlint-common";
+import ResourceRule from './ResourceRule.js';
 
 /** Rule to check that whitespaces on edges of target match those on edges of source */
-class ResourceEdgeWhitespace extends Rule {
+class ResourceEdgeWhitespace extends ResourceRule {
     /** @readonly */ name = "resource-edge-whitespace";
     /** @readonly */ description =
         "Ensure that if there are whitespaces on edges of source string, matching ones are there in target as well";
     /** @readonly */ link = "https://github.com/ilib-js/i18nlint/blob/main/docs/resource-edge-whitespace.md";
-    /** @readonly */ ruleType = "resource";
 
     constructor() {
         super({});
     }
 
-    /** @override */
-    getRuleType() {
-        return this.ruleType;
-    }
-
     /**
      * @override
-     * @param {object} options
-     * @param {import("ilib-tools-common").Resource} options.resource
-     * @param {string} options.file
-     * @param {string} options.locale
      */
-    match({ resource, file, locale }) {
-        const source = resource.getSource();
-        const target = resource.getTarget();
-
+    matchString({ source, target, file, resource }) {
         if ("string" !== typeof source || "string" !== typeof target) {
             return /* don't check when either source or target string is not defined */;
         }
@@ -62,7 +50,7 @@ class ResourceEdgeWhitespace extends Rule {
             rule: this,
             pathName: file,
             source,
-            locale,
+            locale: resource.getTargetLocale()
         };
 
         if (whitespaces.target.leading !== whitespaces.source.leading) {

--- a/src/rules/ResourceICUPluralTranslation.js
+++ b/src/rules/ResourceICUPluralTranslation.js
@@ -20,12 +20,14 @@
 
 import { IntlMessageFormat } from 'intl-messageformat';
 import Locale from 'ilib-locale';
-import { Rule, Result } from 'i18nlint-common';
+import { Result } from 'i18nlint-common';
+
+import ResourceRule from './ResourceRule.js';
 
 /**
  * @class Represent an ilib-lint rule.
  */
-class ResourceICUPluralTranslation extends Rule {
+class ResourceICUPluralTranslation extends ResourceRule {
     /**
      * Make a new rule instance.
      * @constructor
@@ -36,10 +38,6 @@ class ResourceICUPluralTranslation extends Rule {
         this.description = "Ensure that plurals in translated resources are also translated";
         this.sourceLocale = (options && options.sourceLocale) || "en-US";
         this.link = "https://gihub.com/ilib-js/i18nlint/blob/main/docs/resource-icu-plurals-translated.md";
-    }
-
-    getRuleType() {
-        return "resource";
     }
 
     /**
@@ -188,11 +186,11 @@ class ResourceICUPluralTranslation extends Rule {
 
     /**
      * Check a string in a resource for missing translations of plurals or selects.
-     * @private
+     * @override
      */
-    checkString(src, tar, file, resource, sourceLocale, targetLocale, lineNumber) {
-        const sLoc = new Locale(sourceLocale);
-        const tLoc = new Locale(targetLocale);
+    matchString({source, target, file, resource}) {
+        const sLoc = new Locale(resource.getSourceLocale());
+        const tLoc = new Locale(resource.getTargetLocale());
 
         // same language and script means that the translations are allowed to be the same as
         // the source
@@ -201,10 +199,10 @@ class ResourceICUPluralTranslation extends Rule {
         let sourceAst;
         let targetAst;
         try {
-            let imf = new IntlMessageFormat(src, sourceLocale);
+            let imf = new IntlMessageFormat(source, sLoc.getSpec());
             sourceAst = imf.getAst();
 
-            imf = new IntlMessageFormat(tar, targetLocale);
+            imf = new IntlMessageFormat(target, tLoc.getSpec());
             targetAst = imf.getAst();
         } catch (e) {
             // ignore plural syntax errors -- that's a different rule
@@ -214,48 +212,6 @@ class ResourceICUPluralTranslation extends Rule {
         const results = this.traverse(resource, file, sourceAst, targetAst).filter(result => result);
 
         return (results && results.length < 2) ? results[0] : results;
-    }
-
-    /**
-     * @override
-     */
-    match(options) {
-        const { resource, file } = options;
-        const sourceLocale = this.sourceLocale;
-        let problems = [];
-
-        switch (resource.getType()) {
-            case 'string':
-                const tarString = resource.getTarget();
-                if (tarString) {
-                    return this.checkString(resource.getSource(), tarString, file, resource, sourceLocale, options.locale, options.lineNumber);
-                }
-                break;
-
-            case 'array':
-                const srcArray = resource.getSource();
-                const tarArray = resource.getTarget();
-                if (tarArray) {
-                    return srcArray.map((item, i) => {
-                        if (i < tarArray.length && tarArray[i]) {
-                            return this.checkString(srcArray[i], tarArray[i], file, resource, sourceLocale, options.locale, options.lineNumber);
-                        }
-                    }).filter(element => {
-                        return element;
-                    });
-                }
-                break;
-
-            case 'plural':
-                const srcPlural = resource.getSource();
-                const tarPlural = resource.getTarget();
-                if (tarPlural) {
-                    return Object.keys(srcPlural).map(category => {
-                        return this.checkString(srcPlural.other, tarPlural[category], file, resource, sourceLocale, options.locale, options.lineNumber);
-                    });
-                }
-                break;
-        }
     }
 }
 

--- a/src/rules/ResourceICUPluralTranslation.js
+++ b/src/rules/ResourceICUPluralTranslation.js
@@ -132,14 +132,14 @@ class ResourceICUPluralTranslation extends ResourceRule {
 
         // for each plural, try to match it up with the target plural by name and check if
         // there is a translation
-        let results = Object.keys(sourcePlurals).map(name => {
+        let results = Object.keys(sourcePlurals).flatMap(name => {
             const sourcePlural = sourcePlurals[name];
             const targetPlural = targetPlurals[name];
             if (!targetPlural) {
                 // missing target plurals are for a different rule, so don't report it here
                 return;
             }
-            return Object.keys(targetPlural.options).map(category => {
+            return Object.keys(targetPlural.options).flatMap(category => {
                 const sourceCategory = sourcePlural.options[category] ? category : "other";
                 const sourcePluralCat = sourcePlural.options[sourceCategory];
                 if (!sourcePluralCat) return; // nothing to check!
@@ -168,11 +168,11 @@ class ResourceICUPluralTranslation extends ResourceRule {
 
                 // now the plurals may have plurals nested in them, so recursively check them too
                 return result.concat(this.traverse(resource, file, sourcePluralCat.value, targetPlural.options[category].value));
-             }).flat();
-        }).flat();
+             });
+        });
 
         // now recursively handle the tags
-        results = results.concat(Object.keys(sourceTags).map(name => {
+        results = results.concat(Object.keys(sourceTags).flatMap(name => {
             const sourceTag = sourceTags[name];
             const targetTag = targetTags[name];
             if (!targetTag) {
@@ -180,7 +180,7 @@ class ResourceICUPluralTranslation extends ResourceRule {
                 return;
             }
             return this.traverse(resource, file, sourceTag.children, targetTag.children);
-        }).flat());
+        }));
         return results;
     }
 
@@ -211,7 +211,7 @@ class ResourceICUPluralTranslation extends ResourceRule {
 
         const results = this.traverse(resource, file, sourceAst, targetAst).filter(result => result);
 
-        return (results && results.length < 2) ? results[0] : results;
+        return results;
     }
 }
 

--- a/src/rules/ResourceMatcher.js
+++ b/src/rules/ResourceMatcher.js
@@ -66,11 +66,11 @@ class ResourceMatcher extends DeclarativeResourceRule {
     /**
      * @override
      */
-    checkString(re, src, tar, file, resource) {
+    checkString({re, source, target, file, resource}) {
         re.lastIndex = 0;
         let sourceMatches = [];
-        const strippedSrc = stripPlurals(src);
-        const strippedTar = stripPlurals(tar);
+        const strippedSrc = stripPlurals(source);
+        const strippedTar = stripPlurals(target);
 
         let match = re.exec(strippedSrc);
         while (match) {
@@ -93,11 +93,12 @@ class ResourceMatcher extends DeclarativeResourceRule {
                     let value = {
                         severity: this.severity,
                         id: resource.getKey(),
-                        source: src,
+                        source: source,
                         rule: this,
                         pathName: file,
-                        highlight:`Target: ${tar}<e0></e0>`,
-                        description: this.note.replace(/\{matchString\}/g, missing)
+                        highlight:`Target: ${target}<e0></e0>`,
+                        description: this.note.replace(/\{matchString\}/g, missing),
+                        locale: resource.getTargetLocale()
                     };
                     if (typeof(resource.lineNumber) !== 'undefined') {
                         value.lineNumber = resource.lineNumber;

--- a/src/rules/ResourceNoTranslation.js
+++ b/src/rules/ResourceNoTranslation.js
@@ -20,12 +20,14 @@
 
 import Locale from 'ilib-locale';
 
-import { Rule, Result } from 'i18nlint-common';
+import { Result } from 'i18nlint-common';
+
+import ResourceRule from './ResourceRule.js';
 
 /**
  * @class Represent an ilib-lint rule.
  */
-class ResourceNoTranslation extends Rule {
+class ResourceNoTranslation extends ResourceRule {
     #name = "resource-no-translation";
     #description = "Ensure that each resource in a resource file has a proper translation";
     #link = "https://github.com/ilib-js/i18nlint/blob/main/docs/resource-no-translation.md";
@@ -40,16 +42,10 @@ class ResourceNoTranslation extends Rule {
         this.sourceLocale = (options && options.sourceLocale) || "en-US";
     }
 
-    getRuleType() {
-        return "resource";
-    }
-
     /**
      * @override
      */
-    match({ locale, resource, file, lineNumber }) {
-        const source = resource.getSource();
-        const target = resource.getTarget();
+    matchString({source, target, file, resource}) {
         const sourceLocale = new Locale(resource.getSourceLocale());
         const targetLocale = new Locale(resource.getTargetLocale());
         const sourceWords = source.split(/\s+/g).length; // does not work for Asian languages
@@ -74,9 +70,9 @@ class ResourceNoTranslation extends Rule {
                 rule: this,
                 pathName: file,
                 highlight: `Target: <e0>${target || ""}</e0>`,
-                description: `Target string is the same as the source string. This is probably an untranslated resource.`,
+                description: !target ? `Target string is missing a translation.` : `Target string is the same as the source string. This is probably an untranslated resource.`,
                 source,
-                locale
+                locale: targetLocale.getSpec()
             };
             if (typeof(lineNumber) !== 'undefined') {
                 value.lineNumber = lineNumber;

--- a/src/rules/ResourceQuoteStyle.js
+++ b/src/rules/ResourceQuoteStyle.js
@@ -21,6 +21,8 @@ import LocaleInfo from 'ilib-localeinfo';
 import Locale from 'ilib-locale';
 import { Rule, Result } from 'i18nlint-common';
 
+import ResourceRule from './ResourceRule.js';
+
 let LICache = {};
 let regExpsCache = {};
 
@@ -35,7 +37,7 @@ const quotesAsciiAlt = new RegExp(`((^|\\W)'\\s?\\p{Letter}|[a-rt-zA-RT-Z]\\s?'(
 /**
  * @class Represent an ilib-lint rule.
  */
-class ResourceQuoteStyle extends Rule {
+class ResourceQuoteStyle extends ResourceRule {
     /**
      * Make a new rule instance.
      * @constructor
@@ -50,10 +52,6 @@ class ResourceQuoteStyle extends Rule {
             this.localeOnly = true;
         }
         this.link = "https://github.com/ilib-js/i18nlint/blob/main/docs/resource-quote-style.md";
-    }
-
-    getRuleType() {
-        return "resource";
     }
 
     /**
@@ -206,47 +204,10 @@ class ResourceQuoteStyle extends Rule {
     /**
      * @override
      */
-    match(options) {
-        const { locale, resource, file } = options || {};
+    matchString({source, target, resource, file}) {
+        const locale = resource.getTargetLocale();
         const regExps = this.getRegExps(locale);
-        switch (resource.getType()) {
-            case 'string':
-                const tarString = resource.getTarget();
-                if (tarString) {
-                    return this.checkString(resource.getSource(), tarString, resource, file, locale, regExps);
-                }
-                break;
-
-            case 'array':
-                const srcArray = resource.getSource();
-                const tarArray = resource.getTarget();
-                if (tarArray) {
-                    return srcArray.map((item, i) => {
-                        if (i < tarArray.length && tarArray[i]) {
-                            return this.checkString(srcArray[i], tarArray[i], resource, file, locale, regExps);
-                        }
-                    }).filter(element => {
-                        return element;
-                    });
-                }
-                break;
-
-            case 'plural':
-                const srcPlural = resource.getSource();
-                const tarPlural = resource.getTarget();
-                if (tarPlural) {
-                    const hasQuotes = categories.find(category => {
-                        return (srcPlural[category] && srcPlural[category].contains(srcQuote));
-                    });
-
-                    if (hasQuotes) {
-                        return categories.map(category => {
-                            return this.checkString(srcPlural.other, tarPlural[category], resource, file, locale, regExps);
-                        });
-                    }
-                }
-                break;
-        }
+        return this.checkString(source, target, resource, file, locale, regExps);
     }
 }
 

--- a/src/rules/ResourceRule.js
+++ b/src/rules/ResourceRule.js
@@ -1,6 +1,6 @@
 /*
  * ResourceRule.js - subclass of Rule that can iterate over arrays
- * and plurals to check individual strings 
+ * and plurals to check individual strings
  *
  * Copyright © 2023 JEDLSoft
  *

--- a/src/rules/ResourceRule.js
+++ b/src/rules/ResourceRule.js
@@ -60,10 +60,10 @@ class ResourceRule extends Rule {
      *
      * @abstract
      * @param {Object} params parameters for the string matching
-     * @param {String} [source] the source string to match against
-     * @param {String} [target] the target string to match
-     * @param {String} file the file path where the resources came from
-     * @param {Resource} resource the resource that contains the source and/or
+     * @param {String|undefined} params.source the source string to match against
+     * @param {String|undefined} params.target the target string to match
+     * @param {String} params.file the file path where the resources came from
+     * @param {Resource} params.resource the resource that contains the source and/or
      * target string
      * @returns {Result|Array.<Result>|undefined} any results
      * found in this string or undefined if no problems were
@@ -94,8 +94,8 @@ class ResourceRule extends Rule {
                     });
 
                 case 'array':
-                    const srcArray = resource.getSource();
-                    const tarArray = resource.getTarget() || [];
+                    const srcArray = resource.getSource() ?? [];
+                    const tarArray = resource.getTarget() ?? [];
                     results = srcArray.flatMap((item, i) => {
                         return this.matchString({
                             source: srcArray[i],
@@ -107,13 +107,13 @@ class ResourceRule extends Rule {
                     return results && results.length ? results : undefined;
     
                 case 'plural':
-                    const srcPlural = resource.getSource();
-                    const tarPlural = resource.getTarget();
+                    const srcPlural = resource.getSource() ?? {};
+                    const tarPlural = resource.getTarget() ?? {};
                     const categorySet = new Set(Object.keys(srcPlural).concat(Object.keys(tarPlural)));
     
                     results = Array.from(categorySet).flatMap(category => {
                         return this.matchString({
-                            source: srcPlural[category] || srcPlural.other,
+                            source: srcPlural[category] ?? srcPlural.other,
                             target: tarPlural[category],
                             file,
                             resource

--- a/src/rules/ResourceRule.js
+++ b/src/rules/ResourceRule.js
@@ -1,0 +1,114 @@
+/*
+ * ResourceRule.js - subclass of Rule that can iterate over arrays
+ * and plurals to check individual strings 
+ *
+ * Copyright © 2023 JEDLSoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Rule } from 'i18nlint-common';
+
+class ResourceRule extends Rule {
+    /**
+     * Construct a new regular expression-based resource checker.
+     *
+     * The options must contain the following required properties:
+     *
+     * - name - a unique name for this rule
+     * - description - a one-line description of what this rule checks for.
+     *   Example: "Check that URLs in the source also appear in the target"
+     * - note - a one-line note that will be printed on screen when the
+     *   check fails. Example: "The URL {matchString} did not appear in the
+     *   the target." (Currently, matchString is the only replacement
+     *   param that is supported.)
+     * - regexps - an array of strings that encode regular expressions to
+     *   look for
+     * @param {Object} options options as documented above
+     * @constructor
+     */
+    constructor(options) {
+        super(options);
+
+        if (!options || !options.name || !options.description || !options.note) {
+            throw "Missing required options for the ResourceRule constructor";
+        }
+        ["name", "description", "note", "sourceLocale", "link", "severity"].forEach(prop => {
+            this[prop] = options[prop];
+        });
+        this.sourceLocale = this.sourceLocale || "en-US";
+        this.severity = this.severity || "error";
+    }
+
+    /**
+     * All rules of this type are resource rules.
+     *
+     * @override
+     */
+    getRuleType() {
+        return "resource";
+    }
+
+    /**
+     * Check a string pair for problems. In various resources, there are
+     * sometimes no source string or no target string and the source or target
+     * parameters may be undefined or the empty string. It is up to the subclass
+     * to determine what to do with that situation.
+     *
+     * @abstract
+     * @param {Locale} locale locale of this resource
+     * @param {String|undefined} source the source string to check
+     * @param {String|undefined} target the target string to check
+     * @param {String} file the path to the file where this resource was found
+     * @param {Resource} resource the resource where this string came from
+     * @returns {Result|Array.<Result>|undefined} any results
+     * found in this string or undefined if no problems were
+     * found.
+     */
+    matchString(locale, source, target, file, resource) {}
+
+    /**
+     * @override
+     */
+    match(options) {
+        const { locale, resource, file } = options || {};
+        let results;
+
+        switch (resource.getType()) {
+            case 'string':
+                const tarString = resource.getTarget();
+                return this.matchString(locale, resource.getSource(), tarString, file, resource);
+
+            case 'array':
+                const srcArray = resource.getSource();
+                const tarArray = resource.getTarget() || [];
+                results = srcArray.map((item, i) => {
+                    return this.matchString(locale, srcArray[i], tarArray[i], file, resource);
+                }).flat().filter(element => element);
+                return (results && results.length ? results : undefined);
+
+            case 'plural':
+                const srcPlural = resource.getSource();
+                const tarPlural = resource.getTarget();
+                const categorySet = new Set(Object.keys(srcPlural).concat(Object.keys(tarPlural)));
+
+                results = Array.from(categorySet).map(category => {
+                    return this.matchString(locale, srcPlural[category], tarPlural[category], file, resource);
+                }).flat().filter(element => element);
+                return (results && results.length ? results : undefined);
+        }
+    }
+}
+
+export default ResourceRule;

--- a/src/rules/ResourceRule.js
+++ b/src/rules/ResourceRule.js
@@ -39,15 +39,6 @@ class ResourceRule extends Rule {
      */
     constructor(options) {
         super(options);
-
-        if (!options || !options.name || !options.description || !options.note) {
-            throw "Missing required options for the ResourceRule constructor";
-        }
-        ["name", "description", "note", "sourceLocale", "link", "severity"].forEach(prop => {
-            this[prop] = options[prop];
-        });
-        this.sourceLocale = this.sourceLocale || "en-US";
-        this.severity = this.severity || "error";
     }
 
     /**

--- a/src/rules/ResourceSourceChecker.js
+++ b/src/rules/ResourceSourceChecker.js
@@ -18,14 +18,15 @@
  * limitations under the License.
  */
 
-import { Rule, Result } from 'i18nlint-common';
+import { Result } from 'i18nlint-common';
+import DeclarativeResourceRule from './DeclarativeResourceRule.js';
 import { stripPlurals } from './utils.js';
 
 /**
  * @class Resource checker class that checks that any regular expressions
  * that matches in the source also appears in the translation.
  */
-class ResourceSourceChecker extends Rule {
+class ResourceSourceChecker extends DeclarativeResourceRule {
     /**
      * Construct a new regular expression-based resource checker.
      *
@@ -45,99 +46,38 @@ class ResourceSourceChecker extends Rule {
      */
     constructor(options) {
         super(options);
-
-        if (!options || !options.name || !options.description || !options.note || !options.regexps) {
-            throw "Missing required options for the ResourceMatcher constructor";
-        }
-        ["name", "description", "regexps", "note", "sourceLocale", "link"].forEach(prop => {
-            this[prop] = options[prop];
-        });
-        this.severity = options.severity || "error";
-        this.sourceLocale = this.sourceLocale || "en-US";
-
-        // this may throw if you got to the regexp syntax wrong:
-        this.re = this.regexps.map(regexp => new RegExp(regexp, "gu"));
-    }
-
-    getRuleType() {
-        return "resource";
     }
 
     /**
      * @override
      */
-    match(options) {
-        const { locale, resource, file } = options || {};
-        const _this = this;
+    checkString(re, src, file, resource) {
+        re.lastIndex = 0;
+        let matches = [];
+        const strippedSrc = stripPlurals(src);
 
-        /**
-         * @private
-         */
-        function checkString(re, src) {
-            re.lastIndex = 0;
-            let matches = [];
-            const strippedSrc = stripPlurals(src);
-
-            // check the target only
-            re.lastIndex = 0;
-            let match = re.exec(strippedSrc);
-            while (match) {
-                let value = {
-                    severity: _this.severity,
-                    id: resource.getKey(),
-                    locale,
-                    rule: _this,
-                    pathName: file,
-                    highlight: `Source: ${src.substring(0, match.index)}<e0>${match[0]}</e0>${src.substring(match.index+match[0].length)}`,
-                    description: _this.note.replace(/\{matchString\}/g, match[0])
-                };
-                if (typeof(options.lineNumber) !== 'undefined') {
-                    value.lineNumber = options.lineNumber;
-                }
-                matches.push(new Result(value));
-
-                match = re.exec(strippedSrc);
+        // check the target only
+        re.lastIndex = 0;
+        let match = re.exec(strippedSrc);
+        while (match) {
+            let value = {
+                severity: this.severity,
+                id: resource.getKey(),
+                rule: this,
+                pathName: file,
+                highlight: `Source: ${src.substring(0, match.index)}<e0>${match[0]}</e0>${src.substring(match.index+match[0].length)}`,
+                description: this.note.replace(/\{matchString\}/g, match[0])
+            };
+            if (typeof(resource.lineNumber) !== 'undefined') {
+                value.lineNumber = resource.lineNumber;
             }
+            matches.push(new Result(value));
 
-            return matches;
+            match = re.exec(strippedSrc);
         }
 
-        function checkRegExps(src, tar) {
-            let results = [];
-            _this.re.forEach(re => {
-                results = results.concat(checkString(re, src, tar));
-            });
-            results = results.filter(result => result);
-            return results && results.length ? results : undefined;
-        }
-
-        switch (resource.getType()) {
-            case 'string':
-                return checkRegExps(resource.getSource());
-                break;
-
-            case 'array':
-                const srcArray = resource.getSource();
-                if (srcArray) {
-                    const results = srcArray.map((item, i) => {
-                        return checkRegExps(srcArray[i]);
-                    }).flat().filter(element => element);
-                    return (results && results.length ? results : undefined);
-                }
-                break;
-
-            case 'plural':
-                const srcPlural = resource.getSource();
-                const results = Object.keys(srcPlural).map(category => {
-                    if (srcPlural[category]) return checkRegExps(srcPlural[category]);
-                }).flat().filter(element => element);
-                return (results && results.length ? results : undefined);
-                break;
-        }
+        return matches;
     }
-
-    // no match
-    return;
 }
 
 export default ResourceSourceChecker;

--- a/src/rules/ResourceSourceChecker.js
+++ b/src/rules/ResourceSourceChecker.js
@@ -1,6 +1,6 @@
 /*
- * ResourceSourceChecker.js - rule to check if URLs in the source string also
- * appear in the target string
+ * ResourceSourceChecker.js - implement a declarative rule to check
+ * source strings for problems
  *
  * Copyright © 2022-2023 JEDLSoft
  *
@@ -34,10 +34,10 @@ class ResourceSourceChecker extends DeclarativeResourceRule {
      *
      * - name - a unique name for this rule
      * - description - a one-line description of what this rule checks for.
-     *   Example: "Check that URLs in the source also appear in the target"
+     *   Example: "Check that URLs in the source conform to proper URL syntax"
      * - note - a one-line note that will be printed on screen when the
-     *   check fails. Example: "The URL {matchString} did not appear in the
-     *   the target." (Currently, matchString is the only replacement
+     *   check fails. Example: "The URL {matchString} is not well-formed."
+     *   (Currently, matchString is the only replacement
      *   param that is supported.)
      * - regexps - an array of strings that encode regular expressions to
      *   look for
@@ -51,12 +51,12 @@ class ResourceSourceChecker extends DeclarativeResourceRule {
     /**
      * @override
      */
-    checkString(re, src, file, resource) {
+    checkString({re, source, file, resource}) {
         re.lastIndex = 0;
         let matches = [];
-        const strippedSrc = stripPlurals(src);
+        const strippedSrc = stripPlurals(source);
 
-        // check the target only
+        // check the source only
         re.lastIndex = 0;
         let match = re.exec(strippedSrc);
         while (match) {
@@ -65,8 +65,9 @@ class ResourceSourceChecker extends DeclarativeResourceRule {
                 id: resource.getKey(),
                 rule: this,
                 pathName: file,
-                highlight: `Source: ${src.substring(0, match.index)}<e0>${match[0]}</e0>${src.substring(match.index+match[0].length)}`,
-                description: this.note.replace(/\{matchString\}/g, match[0])
+                highlight: `Source: ${source.substring(0, match.index)}<e0>${match[0]}</e0>${source.substring(match.index+match[0].length)}`,
+                description: this.note.replace(/\{matchString\}/g, match[0]),
+                locale: resource.getSourceLocale()
             };
             if (typeof(resource.lineNumber) !== 'undefined') {
                 value.lineNumber = resource.lineNumber;

--- a/src/rules/ResourceTargetChecker.js
+++ b/src/rules/ResourceTargetChecker.js
@@ -1,6 +1,6 @@
 /*
- * ResourceTargetChecker.js - rule to check if URLs in the source string also
- * appear in the target string
+ * ResourceTargetChecker.js - implement a declarative rule to check
+ * target strings for problems
  *
  * Copyright © 2022-2023 JEDLSoft
  *
@@ -34,10 +34,10 @@ class ResourceTargetChecker extends DeclarativeResourceRule {
      *
      * - name - a unique name for this rule
      * - description - a one-line description of what this rule checks for.
-     *   Example: "Check that URLs in the source also appear in the target"
+     *   Example: "Check that URLs in the target are valid."
      * - note - a one-line note that will be printed on screen when the
-     *   check fails. Example: "The URL {matchString} did not appear in the
-     *   the target." (Currently, matchString is the only replacement
+     *   check fails. Example: "The URL {matchString} is not valid."
+     *   (Currently, matchString is the only replacement
      *   param that is supported.)
      * - regexps - an array of strings that encode regular expressions to
      *   look for
@@ -51,10 +51,10 @@ class ResourceTargetChecker extends DeclarativeResourceRule {
     /**
      * @override
      */
-    checkString(re, src, tar, file, resource) {
+    checkString({re, source, target, file, resource}) {
         re.lastIndex = 0;
         let matches = [];
-        const strippedTar = stripPlurals(tar);
+        const strippedTar = stripPlurals(target);
 
         // check the target only, but we need the source in order
         // to construct a Result if necessary
@@ -64,11 +64,12 @@ class ResourceTargetChecker extends DeclarativeResourceRule {
             let value = {
                 severity: this.severity,
                 id: resource.getKey(),
-                source: src,
+                source,
                 rule: this,
                 pathName: file,
-                highlight: `Target: ${tar.substring(0, match.index)}<e0>${match[0]}</e0>${tar.substring(match.index+match[0].length)}`,
-                description: this.note.replace(/\{matchString\}/g, match[0])
+                highlight: `Target: ${target.substring(0, match.index)}<e0>${match[0]}</e0>${target.substring(match.index+match[0].length)}`,
+                description: this.note.replace(/\{matchString\}/g, match[0]),
+                locale: resource.getTargetLocale()
             };
             if (typeof(resource.lineNumber) !== 'undefined') {
                 value.lineNumber = resource.lineNumber;

--- a/src/rules/ResourceTargetChecker.js
+++ b/src/rules/ResourceTargetChecker.js
@@ -18,14 +18,15 @@
  * limitations under the License.
  */
 
-import { Rule, Result } from 'i18nlint-common';
+import { Result } from 'i18nlint-common';
+import DeclarativeResourceRule from './DeclarativeResourceRule.js';
 import { stripPlurals } from './utils.js';
 
 /**
  * @class Resource checker class that checks that any regular expressions
  * that matches in the source also appears in the translation.
  */
-class ResourceTargetChecker extends Rule {
+class ResourceTargetChecker extends DeclarativeResourceRule {
     /**
      * Construct a new regular expression-based resource checker.
      *
@@ -45,109 +46,40 @@ class ResourceTargetChecker extends Rule {
      */
     constructor(options) {
         super(options);
-
-        if (!options || !options.name || !options.description || !options.note || !options.regexps) {
-            throw "Missing required options for the ResourceMatcher constructor";
-        }
-        ["name", "description", "regexps", "note", "sourceLocale", "link"].forEach(prop => {
-            this[prop] = options[prop];
-        });
-        this.severity = options.severity || "error";
-        this.sourceLocale = this.sourceLocale || "en-US";
-
-        // this may throw if you got to the regexp syntax wrong:
-        this.re = this.regexps.map(regexp => new RegExp(regexp, "gu"));
-    }
-
-    getRuleType() {
-        return "resource";
     }
 
     /**
      * @override
      */
-    match(options) {
-        const { locale, resource, file } = options || {};
-        const _this = this;
+    checkString(re, src, tar, file, resource) {
+        re.lastIndex = 0;
+        let matches = [];
+        const strippedTar = stripPlurals(tar);
 
-        /**
-         * @private
-         */
-        function checkString(re, src, tar) {
-            re.lastIndex = 0;
-            let matches = [];
-            const strippedTar = stripPlurals(tar);
-
-            // check the target only
-            re.lastIndex = 0;
-            let match = re.exec(strippedTar);
-            while (match) {
-                let value = {
-                    severity: _this.severity,
-                    id: resource.getKey(),
-                    locale,
-                    source: src,
-                    rule: _this,
-                    pathName: file,
-                    highlight: `Target: ${tar.substring(0, match.index)}<e0>${match[0]}</e0>${tar.substring(match.index+match[0].length)}`,
-                    description: _this.note.replace(/\{matchString\}/g, match[0])
-                };
-                if (typeof(options.lineNumber) !== 'undefined') {
-                    value.lineNumber = options.lineNumber;
-                }
-                matches.push(new Result(value));
-
-                match = re.exec(strippedTar);
+        // check the target only, but we need the source in order
+        // to construct a Result if necessary
+        re.lastIndex = 0;
+        let match = re.exec(strippedTar);
+        while (match) {
+            let value = {
+                severity: this.severity,
+                id: resource.getKey(),
+                source: src,
+                rule: this,
+                pathName: file,
+                highlight: `Target: ${tar.substring(0, match.index)}<e0>${match[0]}</e0>${tar.substring(match.index+match[0].length)}`,
+                description: this.note.replace(/\{matchString\}/g, match[0])
+            };
+            if (typeof(resource.lineNumber) !== 'undefined') {
+                value.lineNumber = resource.lineNumber;
             }
+            matches.push(new Result(value));
 
-            return matches;
+            match = re.exec(strippedTar);
         }
 
-        function checkRegExps(src, tar) {
-            let results = [];
-            _this.re.forEach(re => {
-                results = results.concat(checkString(re, src, tar));
-            });
-            results = results.filter(result => result);
-            return results && results.length ? results : undefined;
-        }
-
-        switch (resource.getType()) {
-            case 'string':
-                const tarString = resource.getTarget();
-                if (tarString) {
-                    return checkRegExps(resource.getSource(), tarString);
-                }
-                break;
-
-            case 'array':
-                const srcArray = resource.getSource();
-                const tarArray = resource.getTarget();
-                if (tarArray) {
-                    const results = srcArray.map((item, i) => {
-                        if (i < tarArray.length && tarArray[i]) {
-                            return checkRegExps(srcArray[i], tarArray[i]);
-                        }
-                    }).flat().filter(element => element);
-                    return (results && results.length ? results : undefined);
-                }
-                break;
-
-            case 'plural':
-                const srcPlural = resource.getSource();
-                const tarPlural = resource.getTarget();
-                if (tarPlural) {
-                    const results = Object.keys(tarPlural).map(category => {
-                        if (tarPlural[category]) return checkRegExps(srcPlural.other, tarPlural[category]);
-                    }).flat().filter(element => element);
-                    return (results && results.length ? results : undefined);
-                }
-                break;
-        }
+        return matches;
     }
-
-    // no match
-    return;
 }
 
 export default ResourceTargetChecker;

--- a/test/testResourceICUPluralTranslation.js
+++ b/test/testResourceICUPluralTranslation.js
@@ -21,7 +21,7 @@ import { ResourceString } from 'ilib-tools-common';
 
 import ResourceICUPluralTranslation from "../src/rules/ResourceICUPluralTranslation.js";
 
-import { Result } from 'i18nlint-common';
+import { Result, IntermediateRepresentation } from 'i18nlint-common';
 
 export const testResourceICUPluralTranslation = {
     testResourceICUPluralTranslationsMatchNoError: function(test) {
@@ -31,16 +31,19 @@ export const testResourceICUPluralTranslation = {
         test.ok(rule);
 
         const actual = rule.match({
-            locale: "de-DE",
-            resource: new ResourceString({
-                key: "plural.test",
-                sourceLocale: "en-US",
-                source: 'There {count, plural, one {is # file} other {are # files}} in the folder.',
-                targetLocale: "de-DE",
-                target: "Es {count, plural, one {gibt # Datei} other {gibt # Dateien}} in dem Ordner.",
-                pathName: "a/b/c.xliff"
+            ir: new IntermediateRepresentation({
+                type: "resource",
+                ir: [new ResourceString({
+                    key: "plural.test",
+                    sourceLocale: "en-US",
+                    source: 'There {count, plural, one {is # file} other {are # files}} in the folder.',
+                    targetLocale: "de-DE",
+                    target: "Es {count, plural, one {gibt # Datei} other {gibt # Dateien}} in dem Ordner.",
+                    pathName: "a/b/c.xliff"
+                })],
+                filePath: "a/b/c.xliff"
             }),
-            file: "x/y"
+            file: "a/b/c.xliff"
         });
         test.ok(!actual);
 
@@ -54,16 +57,19 @@ export const testResourceICUPluralTranslation = {
         test.ok(rule);
 
         const actual = rule.match({
-            locale: "de-DE",
-            resource: new ResourceString({
-                key: "plural.test",
-                sourceLocale: "en-US",
-                source: 'There {count, plural, one {is # file} other {are # files}} in the folder.',
-                targetLocale: "de-DE",
-                target: "Es {count, plural, one {is # file} other {gibt # Dateien}} in dem Ordner.",
-                pathName: "a/b/c.xliff"
+            ir: new IntermediateRepresentation({
+                type: "resource",
+                ir: [new ResourceString({
+                    key: "plural.test",
+                    sourceLocale: "en-US",
+                    source: 'There {count, plural, one {is # file} other {are # files}} in the folder.',
+                    targetLocale: "de-DE",
+                    target: "Es {count, plural, one {is # file} other {gibt # Dateien}} in dem Ordner.",
+                    pathName: "a/b/c.xliff"
+                })],
+                filePath: "a/b/c.xliff"
             }),
-            file: "x/y"
+            file: "a/b/c.xliff"
         });
         const expected = new Result({
             severity: "warning",
@@ -71,7 +77,7 @@ export const testResourceICUPluralTranslation = {
             id: "plural.test",
             highlight: 'Target: <e0>one {is # file}</e0>',
             rule,
-            pathName: "x/y",
+            pathName: "a/b/c.xliff",
             locale: "de-DE",
             source: 'one {is # file}'
         });
@@ -87,16 +93,19 @@ export const testResourceICUPluralTranslation = {
         test.ok(rule);
 
         const actual = rule.match({
-            locale: "de-DE",
-            resource: new ResourceString({
-                key: "plural.test",
-                sourceLocale: "en-US",
-                source: 'There {count, plural, one {is # file and {folderCount, plural, one {{folderCount} folder} other {{folderCount} folders}}} other {are # files and {folderCount, plural, one {{folderCount} folder} other {{folderCount} folders}}}} in the folder.',
-                targetLocale: "de-DE",
-                target: "Es {count, plural, one {gibt # Datei und {folderCount, plural, one {{folderCount} folder} other {{folderCount} folders}}} other {gibt # Dateien und {folderCount, plural, one {{folderCount} folder} other {{folderCount} folders}}}} in dem Ordner.",
-                pathName: "a/b/c.xliff"
+            ir: new IntermediateRepresentation({
+                type: "resource",
+                ir: [new ResourceString({
+                    key: "plural.test",
+                    sourceLocale: "en-US",
+                    source: 'There {count, plural, one {is # file and {folderCount, plural, one {{folderCount} folder} other {{folderCount} folders}}} other {are # files and {folderCount, plural, one {{folderCount} folder} other {{folderCount} folders}}}} in the folder.',
+                    targetLocale: "de-DE",
+                    target: "Es {count, plural, one {gibt # Datei und {folderCount, plural, one {{folderCount} folder} other {{folderCount} folders}}} other {gibt # Dateien und {folderCount, plural, one {{folderCount} folder} other {{folderCount} folders}}}} in dem Ordner.",
+                    pathName: "a/b/c.xliff"
+                })],
+                filePath: "a/b/c.xliff"
             }),
-            file: "x/y"
+            file: "a/b/c.xliff"
         });
         test.ok(actual);
         test.ok(Array.isArray(actual));
@@ -109,7 +118,7 @@ export const testResourceICUPluralTranslation = {
                 id: "plural.test",
                 highlight: 'Target: <e0>one {{folderCount} folder}</e0>',
                 rule,
-                pathName: "x/y",
+                pathName: "a/b/c.xliff",
                 locale: "de-DE",
                 source: 'one {{folderCount} folder}'
             }),
@@ -119,7 +128,7 @@ export const testResourceICUPluralTranslation = {
                 id: "plural.test",
                 highlight: 'Target: <e0>other {{folderCount} folders}</e0>',
                 rule,
-                pathName: "x/y",
+                pathName: "a/b/c.xliff",
                 locale: "de-DE",
                 source: 'other {{folderCount} folders}'
             }),
@@ -129,7 +138,7 @@ export const testResourceICUPluralTranslation = {
                 id: "plural.test",
                 highlight: 'Target: <e0>one {{folderCount} folder}</e0>',
                 rule,
-                pathName: "x/y",
+                pathName: "a/b/c.xliff",
                 locale: "de-DE",
                 source: 'one {{folderCount} folder}'
             }),
@@ -139,7 +148,7 @@ export const testResourceICUPluralTranslation = {
                 id: "plural.test",
                 highlight: 'Target: <e0>other {{folderCount} folders}</e0>',
                 rule,
-                pathName: "x/y",
+                pathName: "a/b/c.xliff",
                 locale: "de-DE",
                 source: 'other {{folderCount} folders}'
             })
@@ -156,16 +165,19 @@ export const testResourceICUPluralTranslation = {
         test.ok(rule);
 
         const actual = rule.match({
-            locale: "de-DE",
-            resource: new ResourceString({
-                key: "plural.test",
-                sourceLocale: "en-US",
-                source: 'There <tagName> {folderCount, plural, one {is {folderCount} folder} other {are {folderCount} folders}} </tagName> in the folder.',
-                targetLocale: "de-DE",
-                target: "Er <tagName> {folderCount, plural, one {ist {folderCount} Ordner} other {zeit {folderCount} Ordner}} </tagName> in dem Ordner.",
-                pathName: "a/b/c.xliff"
+            ir: new IntermediateRepresentation({
+                type: "resource",
+                ir: [new ResourceString({
+                    key: "plural.test",
+                    sourceLocale: "en-US",
+                    source: 'There <tagName> {folderCount, plural, one {is {folderCount} folder} other {are {folderCount} folders}} </tagName> in the folder.',
+                    targetLocale: "de-DE",
+                    target: "Er <tagName> {folderCount, plural, one {ist {folderCount} Ordner} other {zeit {folderCount} Ordner}} </tagName> in dem Ordner.",
+                    pathName: "a/b/c.xliff"
+                })],
+                filePath: "a/b/c.xliff"
             }),
-            file: "x/y"
+            file: "a/b/c.xliff"
         });
         test.ok(!actual);
 
@@ -179,16 +191,19 @@ export const testResourceICUPluralTranslation = {
         test.ok(rule);
 
         const actual = rule.match({
-            locale: "de-DE",
-            resource: new ResourceString({
-                key: "plural.test",
-                sourceLocale: "en-US",
-                source: 'There <tagName> {folderCount, plural, one {is {folderCount} folder} other {are {folderCount} folders}} </tagName> in the folder.',
-                targetLocale: "de-DE",
-                target: "Er <tagName> {folderCount, plural, one {is {folderCount} folder} other {are {folderCount} folders}} </tagName> in dem Ordner.",
-                pathName: "a/b/c.xliff"
+            ir: new IntermediateRepresentation({
+                type: "resource",
+                ir: [new ResourceString({
+                    key: "plural.test",
+                    sourceLocale: "en-US",
+                    source: 'There <tagName> {folderCount, plural, one {is {folderCount} folder} other {are {folderCount} folders}} </tagName> in the folder.',
+                    targetLocale: "de-DE",
+                    target: "Er <tagName> {folderCount, plural, one {is {folderCount} folder} other {are {folderCount} folders}} </tagName> in dem Ordner.",
+                    pathName: "a/b/c.xliff"
+                })],
+                filePath: "a/b/c.xliff"
             }),
-            file: "x/y"
+            file: "a/b/c.xliff"
         });
         test.ok(actual);
         test.ok(Array.isArray(actual));
@@ -201,7 +216,7 @@ export const testResourceICUPluralTranslation = {
                 id: "plural.test",
                 highlight: 'Target: <e0>one {is {folderCount} folder}</e0>',
                 rule,
-                pathName: "x/y",
+                pathName: "a/b/c.xliff",
                 locale: "de-DE",
                 source: 'one {is {folderCount} folder}'
             }),
@@ -211,7 +226,7 @@ export const testResourceICUPluralTranslation = {
                 id: "plural.test",
                 highlight: 'Target: <e0>other {are {folderCount} folders}</e0>',
                 rule,
-                pathName: "x/y",
+                pathName: "a/b/c.xliff",
                 locale: "de-DE",
                 source: 'other {are {folderCount} folders}'
             })
@@ -228,16 +243,19 @@ export const testResourceICUPluralTranslation = {
         test.ok(rule);
 
         const actual = rule.match({
-            locale: "de-DE",
-            resource: new ResourceString({
-                key: "plural.test",
-                sourceLocale: "en-US",
-                source: 'There {count, plural, one {is # file and <tagName> {folderCount, plural, one {{folderCount} folder} other {{folderCount} folders}} </tagName>} other {are # files}} in the folder.',
-                targetLocale: "de-DE",
-                target: "Es {count, plural, one {gibt # Datei und <tagName> {folderCount, plural, one {{folderCount} folder} other {{folderCount} folders}} </tagName>} other {gibt # Dateien}} in dem Ordner.",
-                pathName: "a/b/c.xliff"
+            ir: new IntermediateRepresentation({
+                type: "resource",
+                ir: [new ResourceString({
+                    key: "plural.test",
+                    sourceLocale: "en-US",
+                    source: 'There {count, plural, one {is # file and <tagName> {folderCount, plural, one {{folderCount} folder} other {{folderCount} folders}} </tagName>} other {are # files}} in the folder.',
+                    targetLocale: "de-DE",
+                    target: "Es {count, plural, one {gibt # Datei und <tagName> {folderCount, plural, one {{folderCount} folder} other {{folderCount} folders}} </tagName>} other {gibt # Dateien}} in dem Ordner.",
+                    pathName: "a/b/c.xliff"
+                })],
+                filePath: "a/b/c.xliff"
             }),
-            file: "x/y"
+            file: "a/b/c.xliff"
         });
         test.ok(actual);
         test.ok(Array.isArray(actual));
@@ -250,7 +268,7 @@ export const testResourceICUPluralTranslation = {
                 id: "plural.test",
                 highlight: 'Target: <e0>one {{folderCount} folder}</e0>',
                 rule,
-                pathName: "x/y",
+                pathName: "a/b/c.xliff",
                 locale: "de-DE",
                 source: 'one {{folderCount} folder}'
             }),
@@ -260,7 +278,7 @@ export const testResourceICUPluralTranslation = {
                 id: "plural.test",
                 highlight: 'Target: <e0>other {{folderCount} folders}</e0>',
                 rule,
-                pathName: "x/y",
+                pathName: "a/b/c.xliff",
                 locale: "de-DE",
                 source: 'other {{folderCount} folders}'
             })
@@ -277,16 +295,19 @@ export const testResourceICUPluralTranslation = {
         test.ok(rule);
 
         const actual = rule.match({
-            locale: "de-DE",
-            resource: new ResourceString({
-                key: "plural.test",
-                sourceLocale: "en-US",
-                source: 'There {count, plural, one {is # file and {num, number, currency/GBP} {date, date, medium} {time, time, medium}} other {are # files}} in the folder.',
-                targetLocale: "de-DE",
-                target: "Es {count, plural, one {gibt # Datei und {num, number, currency/GBP} {date, date, medium} {time, time, medium}} other {gibt # Dateien}} in dem Ordner.",
-                pathName: "a/b/c.xliff"
+            ir: new IntermediateRepresentation({
+                type: "resource",
+                ir: [new ResourceString({
+                    key: "plural.test",
+                    sourceLocale: "en-US",
+                    source: 'There {count, plural, one {is # file and {num, number, currency/GBP} {date, date, medium} {time, time, medium}} other {are # files}} in the folder.',
+                    targetLocale: "de-DE",
+                    target: "Es {count, plural, one {gibt # Datei und {num, number, currency/GBP} {date, date, medium} {time, time, medium}} other {gibt # Dateien}} in dem Ordner.",
+                    pathName: "a/b/c.xliff"
+                })],
+                filePath: "a/b/c.xliff"
             }),
-            file: "x/y"
+            file: "a/b/c.xliff"
         });
         test.ok(!actual);
 
@@ -300,16 +321,19 @@ export const testResourceICUPluralTranslation = {
         test.ok(rule);
 
         const actual = rule.match({
-            locale: "de-DE",
-            resource: new ResourceString({
-                key: "plural.test",
-                sourceLocale: "en-US",
-                source: 'There {num, selectordinal, one {first} two {second} other {nth}} in the folder.',
-                targetLocale: "de-DE",
-                target: "Es {num, selectordinal, one {first} two {second} other {nth}} in dem Ordner.",
-                pathName: "a/b/c.xliff"
+            ir: new IntermediateRepresentation({
+                type: "resource",
+                ir: [new ResourceString({
+                    key: "plural.test",
+                    sourceLocale: "en-US",
+                    source: 'There {num, selectordinal, one {first} two {second} other {nth}} in the folder.',
+                    targetLocale: "de-DE",
+                    target: "Es {num, selectordinal, one {first} two {second} other {nth}} in dem Ordner.",
+                    pathName: "a/b/c.xliff"
+                })],
+                filePath: "a/b/c.xliff"
             }),
-            file: "x/y"
+            file: "a/b/c.xliff"
         });
         test.ok(actual);
         test.ok(Array.isArray(actual));
@@ -322,7 +346,7 @@ export const testResourceICUPluralTranslation = {
                 id: "plural.test",
                 highlight: 'Target: <e0>one {first}</e0>',
                 rule,
-                pathName: "x/y",
+                pathName: "a/b/c.xliff",
                 locale: "de-DE",
                 source: 'one {first}'
             }),
@@ -332,7 +356,7 @@ export const testResourceICUPluralTranslation = {
                 id: "plural.test",
                 highlight: 'Target: <e0>two {second}</e0>',
                 rule,
-                pathName: "x/y",
+                pathName: "a/b/c.xliff",
                 locale: "de-DE",
                 source: 'two {second}'
             }),
@@ -342,7 +366,7 @@ export const testResourceICUPluralTranslation = {
                 id: "plural.test",
                 highlight: 'Target: <e0>other {nth}</e0>',
                 rule,
-                pathName: "x/y",
+                pathName: "a/b/c.xliff",
                 locale: "de-DE",
                 source: 'other {nth}'
             })
@@ -359,16 +383,19 @@ export const testResourceICUPluralTranslation = {
         test.ok(rule);
 
         const actual = rule.match({
-            locale: "de-DE",
-            resource: new ResourceString({
-                key: "plural.test",
-                sourceLocale: "en-US",
-                source: 'There {foo, select, male {male string} female {female string} other {other string}} in the folder.',
-                targetLocale: "de-DE",
-                target: "Es {foo, select, male {male string} female {female string} other {other string}} in dem Ordner.",
-                pathName: "a/b/c.xliff"
+            ir: new IntermediateRepresentation({
+                type: "resource",
+                ir: [new ResourceString({
+                    key: "plural.test",
+                    sourceLocale: "en-US",
+                    source: 'There {foo, select, male {male string} female {female string} other {other string}} in the folder.',
+                    targetLocale: "de-DE",
+                    target: "Es {foo, select, male {male string} female {female string} other {other string}} in dem Ordner.",
+                    pathName: "a/b/c.xliff"
+                })],
+                filePath: "a/b/c.xliff"
             }),
-            file: "x/y"
+            file: "a/b/c.xliff"
         });
         test.ok(actual);
         test.ok(Array.isArray(actual));
@@ -381,7 +408,7 @@ export const testResourceICUPluralTranslation = {
                 id: "plural.test",
                 highlight: 'Target: <e0>male {male string}</e0>',
                 rule,
-                pathName: "x/y",
+                pathName: "a/b/c.xliff",
                 locale: "de-DE",
                 source: 'male {male string}'
             }),
@@ -391,7 +418,7 @@ export const testResourceICUPluralTranslation = {
                 id: "plural.test",
                 highlight: 'Target: <e0>female {female string}</e0>',
                 rule,
-                pathName: "x/y",
+                pathName: "a/b/c.xliff",
                 locale: "de-DE",
                 source: 'female {female string}'
             }),
@@ -401,7 +428,7 @@ export const testResourceICUPluralTranslation = {
                 id: "plural.test",
                 highlight: 'Target: <e0>other {other string}</e0>',
                 rule,
-                pathName: "x/y",
+                pathName: "a/b/c.xliff",
                 locale: "de-DE",
                 source: 'other {other string}'
             })
@@ -418,16 +445,19 @@ export const testResourceICUPluralTranslation = {
         test.ok(rule);
 
         const actual = rule.match({
-            locale: "de-DE",
-            resource: new ResourceString({
-                key: "plural.test",
-                sourceLocale: "en-US",
-                source: 'There {count, plural, one {is # file and {folderCount, plural, one {{folderCount} folder} other {{folderCount} folders}}} other {are # files and {folderCount, plural, one {{folderCount} folder} other {{folderCount} folders}}}} in the folder.',
-                targetLocale: "de-DE",
-                target: "Es {count, plural, one {is # file and {folderCount, plural, one {{folderCount} Ordner} other {{folderCount} Ordner}}} other {are # files and {folderCount, plural, one {{folderCount} Ordner} other {{folderCount} Ordner}}}} in the folder.",
-                pathName: "a/b/c.xliff"
+            ir: new IntermediateRepresentation({
+                type: "resource",
+                ir: [new ResourceString({
+                    key: "plural.test",
+                    sourceLocale: "en-US",
+                    source: 'There {count, plural, one {is # file and {folderCount, plural, one {{folderCount} folder} other {{folderCount} folders}}} other {are # files and {folderCount, plural, one {{folderCount} folder} other {{folderCount} folders}}}} in the folder.',
+                    targetLocale: "de-DE",
+                    target: "Es {count, plural, one {is # file and {folderCount, plural, one {{folderCount} Ordner} other {{folderCount} Ordner}}} other {are # files and {folderCount, plural, one {{folderCount} Ordner} other {{folderCount} Ordner}}}} in the folder.",
+                    pathName: "a/b/c.xliff"
+                })],
+                filePath: "a/b/c.xliff"
             }),
-            file: "x/y"
+            file: "a/b/c.xliff"
         });
         test.ok(actual);
         test.ok(Array.isArray(actual));
@@ -440,7 +470,7 @@ export const testResourceICUPluralTranslation = {
                 id: "plural.test",
                 highlight: 'Target: <e0>one {is # file and {plural}}</e0>',
                 rule,
-                pathName: "x/y",
+                pathName: "a/b/c.xliff",
                 locale: "de-DE",
                 source: 'one {is # file and {plural}}'
             }),
@@ -450,7 +480,7 @@ export const testResourceICUPluralTranslation = {
                 id: "plural.test",
                 highlight: 'Target: <e0>other {are # files and {plural}}</e0>',
                 rule,
-                pathName: "x/y",
+                pathName: "a/b/c.xliff",
                 locale: "de-DE",
                 source: 'other {are # files and {plural}}'
             })
@@ -467,16 +497,19 @@ export const testResourceICUPluralTranslation = {
         test.ok(rule);
 
         const actual = rule.match({
-            locale: "ru-RU",
-            resource: new ResourceString({
-                key: "plural.test",
-                sourceLocale: "en-US",
-                source: 'There {count, plural, one {is # file} other {are # files}} in the folder.',
-                targetLocale: "ru-RU",
-                target: 'There {count, plural, one {is # file (Russian)} few {are # files (Russian)} other {are # files (Russian)}} in the folder.',
-                pathName: "a/b/c.xliff"
+            ir: new IntermediateRepresentation({
+                type: "resource",
+                ir: [new ResourceString({
+                    key: "plural.test",
+                    sourceLocale: "en-US",
+                    source: 'There {count, plural, one {is # file} other {are # files}} in the folder.',
+                    targetLocale: "ru-RU",
+                    target: 'There {count, plural, one {is # file (Russian)} few {are # files (Russian)} other {are # files (Russian)}} in the folder.',
+                    pathName: "a/b/c.xliff"
+                })],
+                filePath: "a/b/c.xliff"
             }),
-            file: "x/y"
+            file: "a/b/c.xliff"
         });
         test.ok(!actual);
 
@@ -490,16 +523,19 @@ export const testResourceICUPluralTranslation = {
         test.ok(rule);
 
         const actual = rule.match({
-            locale: "ru-RU",
-            resource: new ResourceString({
-                key: "plural.test",
-                sourceLocale: "en-US",
-                source: 'There {count, plural, one {is # file} other {are # files}} in the folder.',
-                targetLocale: "ru-RU",
-                target: 'There {count, plural, one {is # file} few {are # files} other {are # files}} in the folder.',
-                pathName: "a/b/c.xliff"
+            ir: new IntermediateRepresentation({
+                type: "resource",
+                ir: [new ResourceString({
+                    key: "plural.test",
+                    sourceLocale: "en-US",
+                    source: 'There {count, plural, one {is # file} other {are # files}} in the folder.',
+                    targetLocale: "ru-RU",
+                    target: 'There {count, plural, one {is # file} few {are # files} other {are # files}} in the folder.',
+                    pathName: "a/b/c.xliff"
+                })],
+                filePath: "a/b/c.xliff"
             }),
-            file: "x/y"
+            file: "a/b/c.xliff"
         });
         test.ok(actual);
         test.ok(Array.isArray(actual));
@@ -512,7 +548,7 @@ export const testResourceICUPluralTranslation = {
                 id: "plural.test",
                 highlight: 'Target: <e0>one {is # file}</e0>',
                 rule,
-                pathName: "x/y",
+                pathName: "a/b/c.xliff",
                 locale: "ru-RU",
                 source: 'one {is # file}'
             }),
@@ -522,7 +558,7 @@ export const testResourceICUPluralTranslation = {
                 id: "plural.test",
                 highlight: 'Target: <e0>few {are # files}</e0>',
                 rule,
-                pathName: "x/y",
+                pathName: "a/b/c.xliff",
                 locale: "ru-RU",
                 source: 'other {are # files}'
             }),
@@ -532,7 +568,7 @@ export const testResourceICUPluralTranslation = {
                 id: "plural.test",
                 highlight: 'Target: <e0>other {are # files}</e0>',
                 rule,
-                pathName: "x/y",
+                pathName: "a/b/c.xliff",
                 locale: "ru-RU",
                 source: 'other {are # files}'
             }),
@@ -549,16 +585,19 @@ export const testResourceICUPluralTranslation = {
         test.ok(rule);
 
         const actual = rule.match({
-            locale: "ja-JP",
-            resource: new ResourceString({
-                key: "plural.test",
-                sourceLocale: "en-US",
-                source: 'There {count, plural, one {is # file} other {are # files}} in the folder.',
-                targetLocale: "ja-JP",
-                target: 'There {count, plural, other {are # files (Japanese)}} in the folder.',
-                pathName: "a/b/c.xliff"
+            ir: new IntermediateRepresentation({
+                type: "resource",
+                ir: [new ResourceString({
+                    key: "plural.test",
+                    sourceLocale: "en-US",
+                    source: 'There {count, plural, one {is # file} other {are # files}} in the folder.',
+                    targetLocale: "ja-JP",
+                    target: 'There {count, plural, other {are # files (Japanese)}} in the folder.',
+                    pathName: "a/b/c.xliff"
+                })],
+                filePath: "a/b/c.xliff"
             }),
-            file: "x/y"
+            file: "a/b/c.xliff"
         });
         test.ok(!actual);
 
@@ -572,16 +611,19 @@ export const testResourceICUPluralTranslation = {
         test.ok(rule);
 
         const actual = rule.match({
-            locale: "ja-JP",
-            resource: new ResourceString({
-                key: "plural.test",
-                sourceLocale: "en-US",
-                source: 'There {count, plural, one {is # file} other {are # files}} in the folder.',
-                targetLocale: "ja-JP",
-                target: 'There {count, plural, other {are # files}} in the folder.',
-                pathName: "a/b/c.xliff"
+            ir: new IntermediateRepresentation({
+                type: "resource",
+                ir: [new ResourceString({
+                    key: "plural.test",
+                    sourceLocale: "en-US",
+                    source: 'There {count, plural, one {is # file} other {are # files}} in the folder.',
+                    targetLocale: "ja-JP",
+                    target: 'There {count, plural, other {are # files}} in the folder.',
+                    pathName: "a/b/c.xliff"
+                })],
+                filePath: "a/b/c.xliff"
             }),
-            file: "x/y"
+            file: "a/b/c.xliff"
         });
         test.ok(actual);
 
@@ -591,7 +633,7 @@ export const testResourceICUPluralTranslation = {
             id: "plural.test",
             highlight: 'Target: <e0>other {are # files}</e0>',
             rule,
-            pathName: "x/y",
+            pathName: "a/b/c.xliff",
             locale: "ja-JP",
             source: 'other {are # files}'
         });
@@ -607,16 +649,19 @@ export const testResourceICUPluralTranslation = {
         test.ok(rule);
 
         const actual = rule.match({
-            locale: "fr-FR",
-            resource: new ResourceString({
-                key: "plural.test",
-                sourceLocale: "en-US",
-                source: 'Maximum custodians',
-                targetLocale: "fr-FR",
-                target: "Depositaires maximaux",
-                pathName: "a/b/c.xliff"
+            ir: new IntermediateRepresentation({
+                type: "resource",
+                ir: [new ResourceString({
+                    key: "plural.test",
+                    sourceLocale: "en-US",
+                    source: 'Maximum custodians',
+                    targetLocale: "fr-FR",
+                    target: "Depositaires maximaux",
+                    pathName: "a/b/c.xliff"
+                })],
+                filePath: "a/b/c.xliff"
             }),
-            file: "x/y"
+            file: "a/b/c.xliff"
         });
         test.ok(!actual);
 
@@ -630,16 +675,19 @@ export const testResourceICUPluralTranslation = {
         test.ok(rule);
 
         const actual = rule.match({
-            locale: "fr-FR",
-            resource: new ResourceString({
-                key: "plural.test",
-                sourceLocale: "en-US",
-                source: 'Maximum {max} custodians',
-                targetLocale: "fr-FR",
-                target: "Depositaires maximaux {max}",
-                pathName: "a/b/c.xliff"
+            ir: new IntermediateRepresentation({
+                type: "resource",
+                ir: [new ResourceString({
+                    key: "plural.test",
+                    sourceLocale: "en-US",
+                    source: 'Maximum {max} custodians',
+                    targetLocale: "fr-FR",
+                    target: "Depositaires maximaux {max}",
+                    pathName: "a/b/c.xliff"
+                })],
+                filePath: "a/b/c.xliff"
             }),
-            file: "x/y"
+            file: "a/b/c.xliff"
         });
         test.ok(!actual);
 
@@ -653,16 +701,19 @@ export const testResourceICUPluralTranslation = {
         test.ok(rule);
 
         const actual = rule.match({
-            locale: "de-DE",
-            resource: new ResourceString({
-                key: "plural.test",
-                sourceLocale: "en-US",
-                source: 'There {count, plural, one {is # file} other {are # files}} in the folder.',
-                targetLocale: "de-DE",
-                target: "Es gibt Dateien in dem Ordner.",
-                pathName: "a/b/c.xliff"
+            ir: new IntermediateRepresentation({
+                type: "resource",
+                ir: [new ResourceString({
+                    key: "plural.test",
+                    sourceLocale: "en-US",
+                    source: 'There {count, plural, one {is # file} other {are # files}} in the folder.',
+                    targetLocale: "de-DE",
+                    target: "Es gibt Dateien in dem Ordner.",
+                    pathName: "a/b/c.xliff"
+                })],
+                filePath: "a/b/c.xliff"
             }),
-            file: "x/y"
+            file: "a/b/c.xliff"
         });
         test.ok(!actual);
 

--- a/test/testResourceMatcher.js
+++ b/test/testResourceMatcher.js
@@ -95,17 +95,19 @@ export const testResourceMatcher = {
         const rule = new ResourceMatcher(regexRules[0]);
         test.ok(rule);
 
-        const actual = rule.match({
-            locale: "de-DE",
-            resource: new ResourceString({
-                key: "url.test",
-                sourceLocale: "en-US",
-                source: 'This has an URL in it http://www.box.com',
-                targetLocale: "de-DE",
-                target: "Dies hat ein URL http://www.box.com",
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x/y"
+        const resource = new ResourceString({
+            key: "url.test",
+            sourceLocale: "en-US",
+            source: 'This has an URL in it http://www.box.com',
+            targetLocale: "de-DE",
+            target: "Dies hat ein URL http://www.box.com",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
         });
         test.ok(!actual);
 
@@ -118,21 +120,23 @@ export const testResourceMatcher = {
         const rule = new ResourceMatcher(regexRules[0]);
         test.ok(rule);
 
-        const actual = rule.match({
-            locale: "de-DE",
-            resource: new ResourceArray({
-                key: "url.test",
-                sourceLocale: "en-US",
-                source: [
-                    'This has an URL in it http://www.box.com'
-                ],
-                targetLocale: "de-DE",
-                target: [
-                    "Dies hat ein URL http://www.box.com"
-                ],
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x/y"
+        const resource = new ResourceArray({
+            key: "url.test",
+            sourceLocale: "en-US",
+            source: [
+                'This has an URL in it http://www.box.com'
+            ],
+            targetLocale: "de-DE",
+            target: [
+                "Dies hat ein URL http://www.box.com"
+            ],
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource()[0],
+            target: resource.getTarget()[0],
+            resource,
+            file: "a/b/c.xliff"
         });
         test.ok(!actual);
 
@@ -145,23 +149,25 @@ export const testResourceMatcher = {
         const rule = new ResourceMatcher(regexRules[0]);
         test.ok(rule);
 
-        const actual = rule.match({
-            locale: "de-DE",
-            resource: new ResourceArray({
-                key: "url.test",
-                sourceLocale: "en-US",
-                source: {
-                    one: 'This has an URL in it http://www.box.com',
-                    other: "x"
-                },
-                targetLocale: "de-DE",
-                target: {
-                    one: "Dies hat ein URL http://www.box.com",
-                    other: "y"
-                },
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x/y"
+        const resource = new ResourcePlural({
+            key: "url.test",
+            sourceLocale: "en-US",
+            source: {
+                one: 'This has an URL in it http://www.box.com',
+                other: "x"
+            },
+            targetLocale: "de-DE",
+            target: {
+                one: "Dies hat ein URL http://www.box.com",
+                other: "y"
+            },
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource().other,
+            target: resource.getTarget().other,
+            resource,
+            file: "a/b/c.xliff"
         });
         test.ok(!actual);
 
@@ -174,22 +180,24 @@ export const testResourceMatcher = {
         const rule = new ResourceMatcher(regexRules[0]);
         test.ok(rule);
 
-        const actual = rule.match({
-            locale: "de-DE",
-            resource: new ResourceArray({
-                key: "url.test",
-                sourceLocale: "en-US",
-                source: {
-                    one: 'This has an URL in it http://www.box.com',
-                    other: "x"
-                },
-                targetLocale: "ja-JP",
-                target: {
-                    other: "y"
-                },
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x/y"
+        const resource = new ResourcePlural({
+            key: "url.test",
+            sourceLocale: "en-US",
+            source: {
+                one: 'This has an URL in it http://www.box.com',
+                other: "x"
+            },
+            targetLocale: "ja-JP",
+            target: {
+                other: "y"
+            },
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource().other,
+            target: resource.getTarget().other,
+            resource,
+            file: "a/b/c.xliff"
         });
         test.ok(!actual);
 
@@ -202,17 +210,19 @@ export const testResourceMatcher = {
         const rule = new ResourceMatcher(regexRules[0]);
         test.ok(rule);
 
-        const actual = rule.match({
-            locale: "de-DE",
-            resource: new ResourceString({
-                key: "url.test",
-                sourceLocale: "en-US",
-                source: 'This has an URL in it http://www.box.com',
-                targetLocale: "de-DE",
-                target: "Dies hat ein URL http://www.yahoo.com",
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x/y"
+        const resource = new ResourceString({
+            key: "url.test",
+            sourceLocale: "en-US",
+            source: 'This has an URL in it http://www.box.com',
+            targetLocale: "de-DE",
+            target: "Dies hat ein URL http://www.yahoo.com",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
         });
         test.ok(actual);
         test.equal(actual.length, 1);
@@ -222,7 +232,7 @@ export const testResourceMatcher = {
         test.equal(actual[0].description, "URL 'http://www.box.com' from the source string does not appear in the target string");
         test.equal(actual[0].highlight, "Target: Dies hat ein URL http://www.yahoo.com<e0></e0>");
         test.equal(actual[0].source, 'This has an URL in it http://www.box.com');
-        test.equal(actual[0].pathName, "x/y");
+        test.equal(actual[0].pathName, "a/b/c.xliff");
 
         test.done();
     },
@@ -233,23 +243,25 @@ export const testResourceMatcher = {
         const rule = new ResourceMatcher(regexRules[0]);
         test.ok(rule);
 
-        const actual = rule.match({
-            locale: "de-DE",
-            resource: new ResourceArray({
-                key: "url.test",
-                sourceLocale: "en-US",
-                source: [
-                    'This has an URL in it http://www.box.com',
-                    'This also has an URL in it http://www.google.com'
-                ],
-                targetLocale: "de-DE",
-                target: [
-                    "Dies hat ein URL http://www.yahoo.com",
-                    "Dies hat auch ein URL darin http://www.google.com"
-                ],
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x/y"
+        const resource = new ResourceArray({
+            key: "url.test",
+            sourceLocale: "en-US",
+            source: [
+                'This has an URL in it http://www.box.com',
+                'This also has an URL in it http://www.google.com'
+            ],
+            targetLocale: "de-DE",
+            target: [
+                "Dies hat ein URL http://www.yahoo.com",
+                "Dies hat auch ein URL darin http://www.google.com"
+            ],
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource()[0],
+            target: resource.getTarget()[0],
+            resource,
+            file: "a/b/c.xliff"
         });
         test.ok(actual);
         test.equal(actual.length, 1);
@@ -259,7 +271,7 @@ export const testResourceMatcher = {
         test.equal(actual[0].description, "URL 'http://www.box.com' from the source string does not appear in the target string");
         test.equal(actual[0].highlight, "Target: Dies hat ein URL http://www.yahoo.com<e0></e0>");
         test.equal(actual[0].source, 'This has an URL in it http://www.box.com');
-        test.equal(actual[0].pathName, "x/y");
+        test.equal(actual[0].pathName, "a/b/c.xliff");
 
         test.done();
     },
@@ -270,23 +282,25 @@ export const testResourceMatcher = {
         const rule = new ResourceMatcher(regexRules[0]);
         test.ok(rule);
 
-        const actual = rule.match({
-            locale: "de-DE",
-            resource: new ResourcePlural({
-                key: "url.test",
-                sourceLocale: "en-US",
-                source: {
-                    one: "This has an URL in it http://www.box.com",
-                    other: "This also has an URL in it http://www.google.com"
-                },
-                targetLocale: "de-DE",
-                target: {
-                    one: "Dies hat ein URL http://www.yahoo.com",
-                    other: "Dies hat auch ein URL darin http://www.google.com"
-                },
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x/y"
+        const resource = new ResourcePlural({
+            key: "url.test",
+            sourceLocale: "en-US",
+            source: {
+                one: "This has an URL in it http://www.box.com",
+                other: "This also has an URL in it http://www.google.com"
+            },
+            targetLocale: "de-DE",
+            target: {
+                one: "Dies hat ein URL http://www.yahoo.com",
+                other: "Dies hat auch ein URL darin http://www.google.com"
+            },
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource().one,
+            target: resource.getTarget().one,
+            resource,
+            file: "a/b/c.xliff"
         });
         test.ok(actual);
         test.equal(actual.length, 1);
@@ -296,7 +310,7 @@ export const testResourceMatcher = {
         test.equal(actual[0].description, "URL 'http://www.box.com' from the source string does not appear in the target string");
         test.equal(actual[0].highlight, "Target: Dies hat ein URL http://www.yahoo.com<e0></e0>");
         test.equal(actual[0].source, 'This has an URL in it http://www.box.com');
-        test.equal(actual[0].pathName, "x/y");
+        test.equal(actual[0].pathName, "a/b/c.xliff");
 
         test.done();
     },
@@ -307,17 +321,19 @@ export const testResourceMatcher = {
         const rule = new ResourceMatcher(regexRules[0]);
         test.ok(rule);
 
-        const actual = rule.match({
-            locale: "de-DE",
-            resource: new ResourceString({
-                key: "url.test",
-                sourceLocale: "en-US",
-                source: 'This has a few URLs in it http://www.box.com http://www.google.com/',
-                targetLocale: "de-DE",
-                target: "Dies hat ein URL http://www.box.com http://www.google.com/",
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x/y"
+        const resource = new ResourceString({
+            key: "url.test",
+            sourceLocale: "en-US",
+            source: 'This has a few URLs in it http://www.box.com http://www.google.com/',
+            targetLocale: "de-DE",
+            target: "Dies hat ein URL http://www.box.com http://www.google.com/",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
         });
         test.ok(!actual);
 
@@ -330,17 +346,19 @@ export const testResourceMatcher = {
         const rule = new ResourceMatcher(regexRules[0]);
         test.ok(rule);
 
-        const actual = rule.match({
-            locale: "de-DE",
-            resource: new ResourceString({
-                key: "url.test",
-                sourceLocale: "en-US",
-                source: 'This has a few URLs in it http://www.box.com http://www.google.com/',
-                targetLocale: "de-DE",
-                target: "Dies hat ein URL http://www.google.com/ http://www.box.com",
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x/y"
+        const resource = new ResourceString({
+            key: "url.test",
+            sourceLocale: "en-US",
+            source: 'This has a few URLs in it http://www.box.com http://www.google.com/',
+            targetLocale: "de-DE",
+            target: "Dies hat ein URL http://www.google.com/ http://www.box.com",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
         });
         test.ok(!actual);
 
@@ -353,17 +371,19 @@ export const testResourceMatcher = {
         const rule = new ResourceMatcher(regexRules[0]);
         test.ok(rule);
 
-        const actual = rule.match({
-            locale: "de-DE",
-            resource: new ResourceString({
-                key: "url.test",
-                sourceLocale: "en-US",
-                source: 'This has a few URLs in it http://www.box.com http://www.google.com/',
-                targetLocale: "de-DE",
-                target: "Dies hat ein URL http://www.google.com/",
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x/y"
+        const resource = new ResourceString({
+            key: "url.test",
+            sourceLocale: "en-US",
+            source: 'This has a few URLs in it http://www.box.com http://www.google.com/',
+            targetLocale: "de-DE",
+            target: "Dies hat ein URL http://www.google.com/",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
         });
         test.ok(actual);
         test.equal(actual.length, 1);
@@ -377,17 +397,19 @@ export const testResourceMatcher = {
         const rule = new ResourceMatcher(regexRules[0]);
         test.ok(rule);
 
-        const actual = rule.match({
-            locale: "de-DE",
-            resource: new ResourceString({
-                key: "url.test",
-                sourceLocale: "en-US",
-                source: 'Click on the menu choice "Open with..." to select a different program.',
-                targetLocale: "de-DE",
-                target: 'Klicken Sie auf die Menüauswahl "Öffnen mit...", um ein anderes Programm auszuwählen.',
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x/y"
+        const resource = new ResourceString({
+            key: "url.test",
+            sourceLocale: "en-US",
+            source: 'Click on the menu choice "Open with..." to select a different program.',
+            targetLocale: "de-DE",
+            target: 'Klicken Sie auf die Menüauswahl "Öffnen mit...", um ein anderes Programm auszuwählen.',
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
         });
         test.ok(!actual);
 
@@ -400,17 +422,19 @@ export const testResourceMatcher = {
         const rule = new ResourceMatcher(regexRules[0]);
         test.ok(rule);
 
-        const actual = rule.match({
-            locale: "de-DE",
-            resource: new ResourceString({
-                key: "url.test",
-                sourceLocale: "en-US",
-                source: 'You can remove any of these to reset the association. (e.g. removing an association will allow you to use another acccount.)',
-                targetLocale: "de-DE",
-                target: 'Sie können diese entfernen, um die Zuordnung zurückzusetzen. (z.B. Wenn Sie eine Verknüpfung entfernen, können Sie ein anderes Konto verwenden.)',
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x/y"
+        const resource = new ResourceString({
+            key: "url.test",
+            sourceLocale: "en-US",
+            source: 'You can remove any of these to reset the association. (e.g. removing an association will allow you to use another acccount.)',
+            targetLocale: "de-DE",
+            target: 'Sie können diese entfernen, um die Zuordnung zurückzusetzen. (z.B. Wenn Sie eine Verknüpfung entfernen, können Sie ein anderes Konto verwenden.)',
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
         });
         test.ok(!actual);
 
@@ -423,17 +447,19 @@ export const testResourceMatcher = {
         const rule = new ResourceMatcher(regexRules[1]);
         test.ok(rule);
 
-        const actual = rule.match({
-            locale: "de-DE",
-            resource: new ResourceString({
-                key: "url.test",
-                sourceLocale: "en-US",
-                source: 'This has an {URL} in it.',
-                targetLocale: "de-DE",
-                target: "Dies hat ein {job} drin.",
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x/y"
+        const resource = new ResourceString({
+            key: "url.test",
+            sourceLocale: "en-US",
+            source: 'This has an {URL} in it.',
+            targetLocale: "de-DE",
+            target: "Dies hat ein {job} drin.",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
         });
         test.ok(actual);
         test.equal(actual.length, 1);
@@ -443,7 +469,7 @@ export const testResourceMatcher = {
         test.equal(actual[0].description, "The named parameter '{URL}' from the source string does not appear in the target string");
         test.equal(actual[0].highlight, "Target: Dies hat ein {job} drin.<e0></e0>");
         test.equal(actual[0].source, 'This has an {URL} in it.');
-        test.equal(actual[0].pathName, "x/y");
+        test.equal(actual[0].pathName, "a/b/c.xliff");
 
         test.done();
     },
@@ -454,17 +480,19 @@ export const testResourceMatcher = {
         const rule = new ResourceMatcher(regexRules[1]);
         test.ok(rule);
 
-        const actual = rule.match({
-            locale: "de-DE",
-            resource: new ResourceString({
-                key: "url.test",
-                sourceLocale: "en-US",
-                source: 'This has an {job} in it.',
-                targetLocale: "de-DE",
-                target: "Dies hat ein {job} drin.",
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x/y"
+        const resource = new ResourceString({
+            key: "url.test",
+            sourceLocale: "en-US",
+            source: 'This has an {job} in it.',
+            targetLocale: "de-DE",
+            target: "Dies hat ein {job} drin.",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
         });
         test.ok(!actual);
 
@@ -477,17 +505,19 @@ export const testResourceMatcher = {
         const rule = new ResourceMatcher(regexRules[1]);
         test.ok(rule);
 
-        const actual = rule.match({
-            locale: "de-DE",
-            resource: new ResourceString({
-                key: "url.test",
-                sourceLocale: "en-US",
-                source: 'This has an {URL} in it.',
-                targetLocale: "de-DE",
-                target: "Dies hat ein {URL} drin.",
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x/y"
+        const resource = new ResourceString({
+            key: "url.test",
+            sourceLocale: "en-US",
+            source: 'This has an {URL} in it.',
+            targetLocale: "de-DE",
+            target: "Dies hat ein {URL} drin.",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
         });
         test.ok(!actual);
 
@@ -500,17 +530,19 @@ export const testResourceMatcher = {
         const rule = new ResourceMatcher(regexRules[1]);
         test.ok(rule);
 
-        const actual = rule.match({
-            locale: "de-DE",
-            resource: new ResourceString({
-                key: "url.test",
-                sourceLocale: "en-US",
-                source: 'This has an {URL} in it.',
-                targetLocale: "de-DE",
-                target: "Dies hat ein {job} drin.",
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x/y"
+        const resource = new ResourceString({
+            key: "url.test",
+            sourceLocale: "en-US",
+            source: 'This has an {URL} in it.',
+            targetLocale: "de-DE",
+            target: "Dies hat ein {job} drin.",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
         });
         test.ok(actual);
         test.equal(actual.length, 1);
@@ -520,7 +552,7 @@ export const testResourceMatcher = {
         test.equal(actual[0].description, "The named parameter '{URL}' from the source string does not appear in the target string");
         test.equal(actual[0].highlight, "Target: Dies hat ein {job} drin.<e0></e0>");
         test.equal(actual[0].source, 'This has an {URL} in it.');
-        test.equal(actual[0].pathName, "x/y");
+        test.equal(actual[0].pathName, "a/b/c.xliff");
 
         test.done();
     },
@@ -531,17 +563,19 @@ export const testResourceMatcher = {
         const rule = new ResourceMatcher(regexRules[1]);
         test.ok(rule);
 
-        const actual = rule.match({
-            locale: "de-DE",
-            resource: new ResourceString({
-                key: "url.test",
-                sourceLocale: "en-US",
-                source: 'In {number} {days, plural, one {day} other {days}}',
-                targetLocale: "de-DE",
-                target: "In {number} {days, plural, one {Tag} other {Tagen}}",
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x/y"
+        const resource = new ResourceString({
+            key: "url.test",
+            sourceLocale: "en-US",
+            source: 'In {number} {days, plural, one {day} other {days}}',
+            targetLocale: "de-DE",
+            target: "In {number} {days, plural, one {Tag} other {Tagen}}",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
         });
 
         // {day} is part of the plural, not a replacement param
@@ -556,17 +590,19 @@ export const testResourceMatcher = {
         const rule = new ResourceMatcher(regexRules[1]);
         test.ok(rule);
 
-        const actual = rule.match({
-            locale: "de-DE",
-            resource: new ResourceString({
-                key: "url.test",
-                sourceLocale: "en-US",
-                source: 'In {number} {days, plural, one {day} other {days}}',
-                targetLocale: "de-DE",
-                target: "In {num} {days, plural, one {Tag} other {Tagen}}",
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x/y"
+        const resource = new ResourceString({
+            key: "url.test",
+            sourceLocale: "en-US",
+            source: 'In {number} {days, plural, one {day} other {days}}',
+            targetLocale: "de-DE",
+            target: "In {num} {days, plural, one {Tag} other {Tagen}}",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
         });
         test.ok(actual);
         test.equal(actual.length, 1);
@@ -576,7 +612,7 @@ export const testResourceMatcher = {
         test.equal(actual[0].description, "The named parameter '{number}' from the source string does not appear in the target string");
         test.equal(actual[0].highlight, "Target: In {num} {days, plural, one {Tag} other {Tagen}}<e0></e0>");
         test.equal(actual[0].source, 'In {number} {days, plural, one {day} other {days}}');
-        test.equal(actual[0].pathName, "x/y");
+        test.equal(actual[0].pathName, "a/b/c.xliff");
 
         test.done();
     }

--- a/test/testResourceNoTranslation.js
+++ b/test/testResourceNoTranslation.js
@@ -42,12 +42,12 @@ export const testResourceNoTranslation = {
         });
         const expected = new Result({
             severity: "warning",
-            description: "Target string is the same as the source string. This is probably an untranslated resource.",
+            description: "Target string is missing a translation.",
             id: "translation.test",
             highlight: 'Target: <e0></e0>',
             rule,
             pathName: "x/y",
-            locale: "de-DE",
+            locale: "en-US",
             source: 'This is the source string.'
         });
         test.deepEqual(actual, expected);
@@ -76,7 +76,7 @@ export const testResourceNoTranslation = {
         });
         const expected = new Result({
             severity: "warning",
-            description: "Target string is the same as the source string. This is probably an untranslated resource.",
+            description: "Target string is missing a translation.",
             id: "translation.test",
             highlight: 'Target: <e0></e0>',
             rule,

--- a/test/testResourceNoTranslation.js
+++ b/test/testResourceNoTranslation.js
@@ -29,16 +29,18 @@ export const testResourceNoTranslation = {
         const rule = new ResourceNoTranslation();
         test.ok(rule);
 
-        const actual = rule.match({
-            locale: "de-DE",
-            resource: new ResourceString({
-                key: "translation.test",
-                sourceLocale: "en-US",
-                source: 'This is the source string.',
-                pathName: "a/b/c.xliff",
-                state: "new"
-            }),
-            file: "x/y"
+        const resource = new ResourceString({
+            key: "translation.test",
+            sourceLocale: "en-US",
+            source: 'This is the source string.',
+            pathName: "a/b/c.xliff",
+            state: "new"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
         });
         const expected = new Result({
             severity: "warning",
@@ -46,7 +48,7 @@ export const testResourceNoTranslation = {
             id: "translation.test",
             highlight: 'Target: <e0></e0>',
             rule,
-            pathName: "x/y",
+            pathName: "a/b/c.xliff",
             locale: "en-US",
             source: 'This is the source string.'
         });
@@ -61,18 +63,20 @@ export const testResourceNoTranslation = {
         const rule = new ResourceNoTranslation();
         test.ok(rule);
 
-        const actual = rule.match({
-            locale: "de-DE",
-            resource: new ResourceString({
-                key: "translation.test",
-                sourceLocale: "en-US",
-                source: 'This is the source string.',
-                targetLocale: "de-DE",
-                target: "",
-                pathName: "a/b/c.xliff",
-                state: "new"
-            }),
-            file: "x/y"
+        const resource = new ResourceString({
+            key: "translation.test",
+            sourceLocale: "en-US",
+            source: 'This is the source string.',
+            targetLocale: "de-DE",
+            target: "",
+            pathName: "a/b/c.xliff",
+            state: "new"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
         });
         const expected = new Result({
             severity: "warning",
@@ -80,7 +84,7 @@ export const testResourceNoTranslation = {
             id: "translation.test",
             highlight: 'Target: <e0></e0>',
             rule,
-            pathName: "x/y",
+            pathName: "a/b/c.xliff",
             locale: "de-DE",
             source: 'This is the source string.'
         });
@@ -95,18 +99,20 @@ export const testResourceNoTranslation = {
         const rule = new ResourceNoTranslation();
         test.ok(rule);
 
-        const actual = rule.match({
-            locale: "de-DE",
-            resource: new ResourceString({
-                key: "translation.test",
-                sourceLocale: "en-US",
-                source: 'This is the source string.',
-                targetLocale: "de-DE",
-                target: "This is the source string.",
-                pathName: "a/b/c.xliff",
-                state: "new"
-            }),
-            file: "x/y"
+        const resource = new ResourceString({
+            key: "translation.test",
+            sourceLocale: "en-US",
+            source: 'This is the source string.',
+            targetLocale: "de-DE",
+            target: "This is the source string.",
+            pathName: "a/b/c.xliff",
+            state: "new"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
         });
         const expected = new Result({
             severity: "warning",
@@ -114,7 +120,7 @@ export const testResourceNoTranslation = {
             id: "translation.test",
             highlight: 'Target: <e0>This is the source string.</e0>',
             rule,
-            pathName: "x/y",
+            pathName: "a/b/c.xliff",
             locale: "de-DE",
             source: 'This is the source string.'
         });
@@ -129,18 +135,20 @@ export const testResourceNoTranslation = {
         const rule = new ResourceNoTranslation();
         test.ok(rule);
 
-        const actual = rule.match({
-            locale: "de-DE",
-            resource: new ResourceString({
-                key: "translation.test",
-                sourceLocale: "en-US",
-                source: 'This is the source string.',
-                targetLocale: "de-DE",
-                target: "\nThis is \t the source string.   ",
-                pathName: "a/b/c.xliff",
-                state: "new"
-            }),
-            file: "x/y"
+        const resource = new ResourceString({
+            key: "translation.test",
+            sourceLocale: "en-US",
+            source: 'This is the source string.',
+            targetLocale: "de-DE",
+            target: "\nThis is \t the source string.   ",
+            pathName: "a/b/c.xliff",
+            state: "new"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
         });
         const expected = new Result({
             severity: "warning",
@@ -148,7 +156,7 @@ export const testResourceNoTranslation = {
             id: "translation.test",
             highlight: 'Target: <e0>\nThis is \t the source string.   </e0>',
             rule,
-            pathName: "x/y",
+            pathName: "a/b/c.xliff",
             locale: "de-DE",
             source: 'This is the source string.'
         });
@@ -163,18 +171,20 @@ export const testResourceNoTranslation = {
         const rule = new ResourceNoTranslation();
         test.ok(rule);
 
-        const actual = rule.match({
-            locale: "de-DE",
-            resource: new ResourceString({
-                key: "translation.test",
-                sourceLocale: "en-US",
-                source: 'This is the source string.',
-                targetLocale: "de-DE",
-                target: "This is the Source String.",
-                pathName: "a/b/c.xliff",
-                state: "new"
-            }),
-            file: "x/y"
+        const resource = new ResourceString({
+            key: "translation.test",
+            sourceLocale: "en-US",
+            source: 'This is the source string.',
+            targetLocale: "de-DE",
+            target: "This is the Source String.",
+            pathName: "a/b/c.xliff",
+            state: "new"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
         });
         const expected = new Result({
             severity: "warning",
@@ -182,7 +192,7 @@ export const testResourceNoTranslation = {
             id: "translation.test",
             highlight: 'Target: <e0>This is the Source String.</e0>',
             rule,
-            pathName: "x/y",
+            pathName: "a/b/c.xliff",
             locale: "de-DE",
             source: 'This is the source string.'
         });
@@ -197,18 +207,20 @@ export const testResourceNoTranslation = {
         const rule = new ResourceNoTranslation();
         test.ok(rule);
 
-        const actual = rule.match({
-            locale: "de-DE",
-            resource: new ResourceString({
-                key: "translation.test",
-                sourceLocale: "en-US",
-                source: 'This is the source string.',
-                targetLocale: "en-GB",
-                target: "This is the source string.",
-                pathName: "a/b/c.xliff",
-                state: "new"
-            }),
-            file: "x/y"
+        const resource = new ResourceString({
+            key: "translation.test",
+            sourceLocale: "en-US",
+            source: 'This is the source string.',
+            targetLocale: "en-GB",
+            target: "This is the source string.",
+            pathName: "a/b/c.xliff",
+            state: "new"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
         });
 
         // no results because the source and target both have the same
@@ -225,18 +237,20 @@ export const testResourceNoTranslation = {
         const rule = new ResourceNoTranslation();
         test.ok(rule);
 
-        const actual = rule.match({
-            locale: "de-DE",
-            resource: new ResourceString({
-                key: "translation.test",
-                sourceLocale: "en-US",
-                source: 'This is the source string.',
-                pathName: "a/b/c.xliff",
-                targetLocale: "de-DE",
-                target: "Dies ist die Zielzeichenfolge.",
-                state: "new"
-            }),
-            file: "x/y"
+        const resource = new ResourceString({
+            key: "translation.test",
+            sourceLocale: "en-US",
+            source: 'This is the source string.',
+            pathName: "a/b/c.xliff",
+            targetLocale: "de-DE",
+            target: "Dies ist die Zielzeichenfolge.",
+            state: "new"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
         });
         // text is different, so no problem here
         test.ok(!actual);
@@ -250,19 +264,21 @@ export const testResourceNoTranslation = {
         const rule = new ResourceNoTranslation();
         test.ok(rule);
 
-        const actual = rule.match({
-            locale: "de-DE",
-            resource: new ResourceString({
-                key: "translation.test",
-                sourceLocale: "en-US",
-                source: 'This is the source string.',
-                dnt: true,
-                targetLocale: "en-GB",
-                target: "This is the source string.",
-                pathName: "a/b/c.xliff",
-                state: "new"
-            }),
-            file: "x/y"
+        const resource = new ResourceString({
+            key: "translation.test",
+            sourceLocale: "en-US",
+            source: 'This is the source string.',
+            dnt: true,
+            targetLocale: "en-GB",
+            target: "This is the source string.",
+            pathName: "a/b/c.xliff",
+            state: "new"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
         });
 
         // no results because the resource has the Do Not
@@ -278,18 +294,20 @@ export const testResourceNoTranslation = {
         const rule = new ResourceNoTranslation();
         test.ok(rule);
 
-        const actual = rule.match({
-            locale: "de-DE",
-            resource: new ResourceString({
-                key: "translation.test",
-                sourceLocale: "en-US",
-                source: 'this-is-kabab-text',
-                targetLocale: "de-DE",
-                target: "this-is-kabab-text",
-                pathName: "a/b/c.xliff",
-                state: "new"
-            }),
-            file: "x/y"
+        const resource = new ResourceString({
+            key: "translation.test",
+            sourceLocale: "en-US",
+            source: 'this-is-kabab-text',
+            targetLocale: "de-DE",
+            target: "this-is-kabab-text",
+            pathName: "a/b/c.xliff",
+            state: "new"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
         });
 
         // no results because single-word text is automatically DNT
@@ -304,18 +322,20 @@ export const testResourceNoTranslation = {
         const rule = new ResourceNoTranslation();
         test.ok(rule);
 
-        const actual = rule.match({
-            locale: "de-DE",
-            resource: new ResourceString({
-                key: "translation.test",
-                sourceLocale: "en-US",
-                source: 'test',
-                targetLocale: "de-DE",
-                target: "test",
-                pathName: "a/b/c.xliff",
-                state: "new"
-            }),
-            file: "x/y"
+        const resource = new ResourceString({
+            key: "translation.test",
+            sourceLocale: "en-US",
+            source: 'test',
+            targetLocale: "de-DE",
+            target: "test",
+            pathName: "a/b/c.xliff",
+            state: "new"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
         });
 
         // no results because single word text is automatically DNT

--- a/test/testResourceQuoteStyle.js
+++ b/test/testResourceQuoteStyle.js
@@ -87,16 +87,18 @@ export const testResourceQuoteStyle = {
         const rule = new ResourceQuoteStyle();
         test.ok(rule);
 
-        const actual = rule.match({
-            locale: "de-DE",
-            resource: new ResourceString({
-                key: "quote.test",
-                sourceLocale: "en-US",
-                source: 'This string contains “quotes” in it.',
-                targetLocale: "de-DE",
-                target: "Diese Zeichenfolge enthält 'Anführungszeichen'.",
-                pathName: "a/b/c.xliff"
-            }),
+        const resource = new ResourceString({
+            key: "quote.test",
+            sourceLocale: "en-US",
+            source: 'This string contains “quotes” in it.',
+            targetLocale: "de-DE",
+            target: "Diese Zeichenfolge enthält 'Anführungszeichen'.",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
             file: "x"
         });
         // if the source contains native quotes, the target must too
@@ -123,16 +125,18 @@ export const testResourceQuoteStyle = {
         });
         test.ok(rule);
 
-        const actual = rule.match({
-            locale: "de-DE",
-            resource: new ResourceString({
-                key: "quote.test",
-                sourceLocale: "en-US",
-                source: 'This string contains “quotes” in it.',
-                targetLocale: "de-DE",
-                target: 'Diese Zeichenfolge enthält "Anführungszeichen".',
-                pathName: "a/b/c.xliff"
-            }),
+        const resource = new ResourceString({
+            key: "quote.test",
+            sourceLocale: "en-US",
+            source: 'This string contains “quotes” in it.',
+            targetLocale: "de-DE",
+            target: 'Diese Zeichenfolge enthält "Anführungszeichen".',
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
             file: "x"
         });
         // if the source contains native quotes, the target must too
@@ -157,16 +161,18 @@ export const testResourceQuoteStyle = {
         const rule = new ResourceQuoteStyle();
         test.ok(rule);
 
-        const actual = rule.match({
-            locale: "de-DE",
-            resource: new ResourceString({
-                key: "quote.test",
-                sourceLocale: "en-US",
-                source: 'This string contains "quotes" in it.',
-                targetLocale: "de-DE",
-                target: "Diese Zeichenfolge enthält „Anführungszeichen“.",
-                pathName: "a/b/c.xliff"
-            }),
+        const resource = new ResourceString({
+            key: "quote.test",
+            sourceLocale: "en-US",
+            source: 'This string contains "quotes" in it.',
+            targetLocale: "de-DE",
+            target: "Diese Zeichenfolge enthält „Anführungszeichen“.",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
             file: "x"
         });
         // if the source contains ASCII quotes, the target is allowed to have native quotes
@@ -181,16 +187,18 @@ export const testResourceQuoteStyle = {
         const rule = new ResourceQuoteStyle();
         test.ok(rule);
 
-        const actual = rule.match({
-            locale: "ru-RU",
-            resource: new ResourceString({
-                key: "quote.test",
-                sourceLocale: "en-US",
-                source: 'Click on "My Documents" to see more',
-                targetLocale: "ru-RU",
-                target: "Click on «Мои документы» to see more",
-                pathName: "a/b/c.xliff"
-            }),
+        const resource = new ResourceString({
+            key: "quote.test",
+            sourceLocale: "en-US",
+            source: 'Click on "My Documents" to see more',
+            targetLocale: "ru-RU",
+            target: "Click on «Мои документы» to see more",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
             file: "x"
         });
         // if the source contains ASCII quotes, the target is allowed to have native quotes
@@ -205,16 +213,18 @@ export const testResourceQuoteStyle = {
         const rule = new ResourceQuoteStyle();
         test.ok(rule);
 
-        const actual = rule.match({
-            locale: "ru-RU",
-            resource: new ResourceString({
-                key: "quote.test",
-                sourceLocale: "en-US",
-                source: '"My Documents"',
-                targetLocale: "ru-RU",
-                target: "«Мои документы»",
-                pathName: "a/b/c.xliff"
-            }),
+        const resource = new ResourceString({
+            key: "quote.test",
+            sourceLocale: "en-US",
+            source: '"My Documents"',
+            targetLocale: "ru-RU",
+            target: "«Мои документы»",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
             file: "x"
         });
         // if the source contains ASCII quotes, the target is allowed to have native quotes
@@ -229,17 +239,19 @@ export const testResourceQuoteStyle = {
         const rule = new ResourceQuoteStyle();
         test.ok(rule);
 
-        const actual = rule.match({
-            locale: "de-DE",
-            resource: new ResourceString({
-                key: "quote.test",
-                sourceLocale: "en-US",
-                source: 'This string contains "quotes" in it.',
-                targetLocale: "de-DE",
-                target: 'Diese Zeichenfolge enthält "Anführungszeichen".',
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x/y"
+        const resource = new ResourceString({
+            key: "quote.test",
+            sourceLocale: "en-US",
+            source: 'This string contains "quotes" in it.',
+            targetLocale: "de-DE",
+            target: 'Diese Zeichenfolge enthält "Anführungszeichen".',
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
         });
         test.ok(!actual);
 
@@ -252,17 +264,19 @@ export const testResourceQuoteStyle = {
         const rule = new ResourceQuoteStyle();
         test.ok(rule);
 
-        const actual = rule.match({
-            locale: "de-DE",
-            resource: new ResourceString({
-                key: "quote.test",
-                sourceLocale: "en-US",
-                source: 'This string contains "quotes" in it.',
-                targetLocale: "de-DE",
-                target: "Diese Zeichenfolge enthält 'Anführungszeichen'.",
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x/y"
+        const resource = new ResourceString({
+            key: "quote.test",
+            sourceLocale: "en-US",
+            source: 'This string contains "quotes" in it.',
+            targetLocale: "de-DE",
+            target: "Diese Zeichenfolge enthält 'Anführungszeichen'.",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
         });
         // if the source contains ascii quotes, the target should match
         const expected = new Result({
@@ -273,7 +287,7 @@ export const testResourceQuoteStyle = {
             highlight: "Target: Diese Zeichenfolge enthält <e0>'</e0>Anführungszeichen<e1>'</e1>.",
             rule,
             locale: "de-DE",
-            pathName: "x/y"
+            pathName: "a/b/c.xliff"
         });
         test.deepEqual(actual, expected);
 
@@ -286,16 +300,18 @@ export const testResourceQuoteStyle = {
         const rule = new ResourceQuoteStyle();
         test.ok(rule);
 
-        const actual = rule.match({
-            locale: "de-DE",
-            resource: new ResourceString({
-                key: "quote.test",
-                sourceLocale: "en-US",
-                source: 'This string contains ‘quotes’ in it.',
-                targetLocale: "de-DE",
-                target: "Diese Zeichenfolge enthält 'Anführungszeichen'.",
-                pathName: "a/b/c.xliff"
-            }),
+        const resource = new ResourceString({
+            key: "quote.test",
+            sourceLocale: "en-US",
+            source: 'This string contains ‘quotes’ in it.',
+            targetLocale: "de-DE",
+            target: "Diese Zeichenfolge enthält 'Anführungszeichen'.",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
             file: "a/b"
         });
         const expected = new Result({
@@ -320,17 +336,19 @@ export const testResourceQuoteStyle = {
         const rule = new ResourceQuoteStyle();
         test.ok(rule);
 
-        const actual = rule.match({
-            locale: "de-DE",
-            resource: new ResourceString({
-                key: "quote.test",
-                sourceLocale: "en-US",
-                source: 'This string contains "quotes" in it.',
-                targetLocale: "de-DE",
-                target: "Diese Zeichenfolge enthält „Anführungszeichen“.",
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x/y"
+        const resource = new ResourceString({
+            key: "quote.test",
+            sourceLocale: "en-US",
+            source: 'This string contains "quotes" in it.',
+            targetLocale: "de-DE",
+            target: "Diese Zeichenfolge enthält „Anführungszeichen“.",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
         });
         test.ok(!actual);
 
@@ -343,17 +361,19 @@ export const testResourceQuoteStyle = {
         const rule = new ResourceQuoteStyle();
         test.ok(rule);
 
-        const actual = rule.match({
-            locale: "de-DE",
-            resource: new ResourceString({
-                key: "quote.test",
-                sourceLocale: "en-US",
-                source: 'This string contains quotes in it.',
-                targetLocale: "de-DE",
-                target: "Diese Zeichenfolge enthält Anführungszeichen.",
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x/y"
+        const resource = new ResourceString({
+            key: "quote.test",
+            sourceLocale: "en-US",
+            source: 'This string contains quotes in it.',
+            targetLocale: "de-DE",
+            target: "Diese Zeichenfolge enthält Anführungszeichen.",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
         });
         test.ok(!actual);
 
@@ -366,17 +386,19 @@ export const testResourceQuoteStyle = {
         const rule = new ResourceQuoteStyle();
         test.ok(rule);
 
-        const actual = rule.match({
-            locale: "fr-FR",
-            resource: new ResourceString({
-                key: "quote.test",
-                sourceLocale: "en-US",
-                source: 'This string contains "quotes" in it.',
-                targetLocale: "fr-FR",
-                target: "Le string contient de «guillemets».",
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x/y"
+        const resource = new ResourceString({
+            key: "quote.test",
+            sourceLocale: "en-US",
+            source: 'This string contains "quotes" in it.',
+            targetLocale: "fr-FR",
+            target: "Le string contient de «guillemets».",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
         });
         test.ok(!actual);
 
@@ -389,17 +411,19 @@ export const testResourceQuoteStyle = {
         const rule = new ResourceQuoteStyle();
         test.ok(rule);
 
-        const actual = rule.match({
-            locale: "fr-FR",
-            resource: new ResourceString({
-                key: "quote.test",
-                sourceLocale: "en-US",
-                source: 'This string contains "quotes" in it.',
-                targetLocale: "fr-FR",
-                target: "Le string contient de « guillemets ».",
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x/y"
+        const resource = new ResourceString({
+            key: "quote.test",
+            sourceLocale: "en-US",
+            source: 'This string contains "quotes" in it.',
+            targetLocale: "fr-FR",
+            target: "Le string contient de « guillemets ».",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
         });
         test.ok(!actual);
 
@@ -412,17 +436,19 @@ export const testResourceQuoteStyle = {
         const rule = new ResourceQuoteStyle();
         test.ok(rule);
 
-        const actual = rule.match({
-            locale: "fr-FR",
-            resource: new ResourceString({
-                key: "quote.test",
-                sourceLocale: "en-US",
-                source: 'This string contains "quotes" in it.',
-                targetLocale: "fr-FR",
-                target: "Le string contient de « guillemets ».",
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x/y"
+        const resource = new ResourceString({
+            key: "quote.test",
+            sourceLocale: "en-US",
+            source: 'This string contains "quotes" in it.',
+            targetLocale: "fr-FR",
+            target: "Le string contient de « guillemets ».",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
         });
         test.ok(!actual);
 
@@ -436,17 +462,19 @@ export const testResourceQuoteStyle = {
         const rule = new ResourceQuoteStyle();
         test.ok(rule);
 
-        const actual = rule.match({
-            locale: "de-DE",
-            resource: new ResourceString({
-                key: "quote.test",
-                sourceLocale: "en-US",
-                source: 'This string contains quotes in it.',
-                targetLocale: "de-DE",
-                target: "Diese Zeichenfolge enthält „Anführungszeichen“.",
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x/y"
+        const resource = new ResourceString({
+            key: "quote.test",
+            sourceLocale: "en-US",
+            source: 'This string contains quotes in it.',
+            targetLocale: "de-DE",
+            target: "Diese Zeichenfolge enthält „Anführungszeichen“.",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
         });
         test.ok(!actual);
 
@@ -459,17 +487,19 @@ export const testResourceQuoteStyle = {
         const rule = new ResourceQuoteStyle();
         test.ok(rule);
 
-        const actual = rule.match({
-            locale: "de-DE",
-            resource: new ResourceString({
-                key: "quote.test",
-                sourceLocale: "en-US",
-                source: 'This string contains ‘quotes’ in it.',
-                targetLocale: "de-DE",
-                target: "Diese Zeichenfolge enthält ‚Anführungszeichen‘.",
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x/y"
+        const resource = new ResourceString({
+            key: "quote.test",
+            sourceLocale: "en-US",
+            source: 'This string contains ‘quotes’ in it.',
+            targetLocale: "de-DE",
+            target: "Diese Zeichenfolge enthält ‚Anführungszeichen‘.",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
         });
         test.ok(!actual);
 
@@ -482,17 +512,19 @@ export const testResourceQuoteStyle = {
         const rule = new ResourceQuoteStyle();
         test.ok(rule);
 
-        const actual = rule.match({
-            locale: "de-DE",
-            resource: new ResourceString({
-                key: "quote.test",
-                sourceLocale: "en-US",
-                source: "This string doesn't contain quotes in it.",
-                targetLocale: "de-DE",
-                target: "Diese Zeichenfolge enthält nicht Anführungszeichen.",
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x/y"
+        const resource = new ResourceString({
+            key: "quote.test",
+            sourceLocale: "en-US",
+            source: "This string doesn't contain quotes in it.",
+            targetLocale: "de-DE",
+            target: "Diese Zeichenfolge enthält nicht Anführungszeichen.",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
         });
         test.ok(!actual);
 
@@ -505,17 +537,19 @@ export const testResourceQuoteStyle = {
         const rule = new ResourceQuoteStyle();
         test.ok(rule);
 
-        const actual = rule.match({
-            locale: "de-DE",
-            resource: new ResourceString({
-                key: "quote.test",
-                sourceLocale: "en-US",
-                source: "This string doesn't contain quotes in it. The user's keyboard is working",
-                targetLocale: "de-DE",
-                target: "Diese Zeichenfolge enthält nicht Anführungszeichen. Der Tastenbord des Users funktioniert.",
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x/y"
+        const resource = new ResourceString({
+            key: "quote.test",
+            sourceLocale: "en-US",
+            source: "This string doesn't contain quotes in it. The user's keyboard is working",
+            targetLocale: "de-DE",
+            target: "Diese Zeichenfolge enthält nicht Anführungszeichen. Der Tastenbord des Users funktioniert.",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
         });
         test.ok(!actual);
 
@@ -528,17 +562,19 @@ export const testResourceQuoteStyle = {
         const rule = new ResourceQuoteStyle();
         test.ok(rule);
 
-        const actual = rule.match({
-            locale: "fr-FR",
-            resource: new ResourceString({
-                key: "quote.test",
-                sourceLocale: "en-US",
-                source: 'This string contains "quotes" in it.',
-                targetLocale: "fr-FR",
-                target: "L'expression contient de «guillemets». C'est tres bizarre !",
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x/y"
+        const resource = new ResourceString({
+            key: "quote.test",
+            sourceLocale: "en-US",
+            source: 'This string contains "quotes" in it.',
+            targetLocale: "fr-FR",
+            target: "L'expression contient de «guillemets». C'est tres bizarre !",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
         });
         test.ok(!actual);
 
@@ -551,17 +587,19 @@ export const testResourceQuoteStyle = {
         const rule = new ResourceQuoteStyle();
         test.ok(rule);
 
-        const actual = rule.match({
-            locale: "fr-FR",
-            resource: new ResourceString({
-                key: "quote.test",
-                sourceLocale: "en-US",
-                source: 'This string contains "quotes" in it.',
-                targetLocale: "fr-FR",
-                target: "L'expression contient de « guillemets ». C'est tres bizarre !",
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x/y"
+        const resource = new ResourceString({
+            key: "quote.test",
+            sourceLocale: "en-US",
+            source: 'This string contains "quotes" in it.',
+            targetLocale: "fr-FR",
+            target: "L'expression contient de « guillemets ». C'est tres bizarre !",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
         });
         test.ok(!actual);
 
@@ -574,17 +612,19 @@ export const testResourceQuoteStyle = {
         const rule = new ResourceQuoteStyle();
         test.ok(rule);
 
-        const actual = rule.match({
-            locale: "fr-FR",
-            resource: new ResourceString({
-                key: "quote.test",
-                sourceLocale: "en-US",
-                source: 'This string contains "quotes" in it.',
-                targetLocale: "fr-FR",
-                target: "L'expression contient de « guillemets ». C'est tres bizarre !",
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x/y"
+        const resource = new ResourceString({
+            key: "quote.test",
+            sourceLocale: "en-US",
+            source: 'This string contains "quotes" in it.',
+            targetLocale: "fr-FR",
+            target: "L'expression contient de « guillemets ». C'est tres bizarre !",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
         });
         test.ok(!actual);
 
@@ -597,17 +637,19 @@ export const testResourceQuoteStyle = {
         const rule = new ResourceQuoteStyle();
         test.ok(rule);
 
-        const actual = rule.match({
-            locale: "fr-FR",
-            resource: new ResourceString({
-                key: "quote.test",
-                sourceLocale: "en-US",
-                source: 'This string does not contain quotes in it.',
-                targetLocale: "fr-FR",
-                target: "L'expression ne contient pas de guillemets.",
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x/y"
+        const resource = new ResourceString({
+            key: "quote.test",
+            sourceLocale: "en-US",
+            source: 'This string does not contain quotes in it.',
+            targetLocale: "fr-FR",
+            target: "L'expression ne contient pas de guillemets.",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
         });
         test.ok(!actual);
 
@@ -620,17 +662,19 @@ export const testResourceQuoteStyle = {
         const rule = new ResourceQuoteStyle();
         test.ok(rule);
 
-        const actual = rule.match({
-            locale: "fr-FR",
-            resource: new ResourceString({
-                key: "quote.test",
-                sourceLocale: "en-US",
-                source: 'This string does not contain quotes in it.',
-                targetLocale: "fr-FR",
-                target: "L’expression ne contient pas de guillemets.",
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x/y"
+        const resource = new ResourceString({
+            key: "quote.test",
+            sourceLocale: "en-US",
+            source: 'This string does not contain quotes in it.',
+            targetLocale: "fr-FR",
+            target: "L’expression ne contient pas de guillemets.",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
         });
         test.ok(!actual);
 
@@ -643,17 +687,19 @@ export const testResourceQuoteStyle = {
         const rule = new ResourceQuoteStyle();
         test.ok(rule);
 
-        const actual = rule.match({
-            locale: "fr-FR",
-            resource: new ResourceString({
-                key: "quote.test",
-                sourceLocale: "en-US",
-                source: "This string's contents do not contain quotes in it.",
-                targetLocale: "fr-FR",
-                target: "L'expression ne contient pas de guillemets.",
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x/y"
+        const resource = new ResourceString({
+            key: "quote.test",
+            sourceLocale: "en-US",
+            source: "This string's contents do not contain quotes in it.",
+            targetLocale: "fr-FR",
+            target: "L'expression ne contient pas de guillemets.",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
         });
         test.ok(!actual);
 
@@ -666,17 +712,19 @@ export const testResourceQuoteStyle = {
         const rule = new ResourceQuoteStyle();
         test.ok(rule);
 
-        const actual = rule.match({
-            locale: "fr-FR",
-            resource: new ResourceString({
-                key: "quote.test",
-                sourceLocale: "en-US",
-                source: "This string’s contents do not contain quotes in it.",
-                targetLocale: "fr-FR",
-                target: "L'expression ne contient pas de guillemets.",
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x/y"
+        const resource = new ResourceString({
+            key: "quote.test",
+            sourceLocale: "en-US",
+            source: "This string’s contents do not contain quotes in it.",
+            targetLocale: "fr-FR",
+            target: "L'expression ne contient pas de guillemets.",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
         });
         test.ok(!actual);
 
@@ -689,17 +737,19 @@ export const testResourceQuoteStyle = {
         const rule = new ResourceQuoteStyle();
         test.ok(rule);
 
-        const actual = rule.match({
-            locale: "fr-FR",
-            resource: new ResourceString({
-                key: "quote.test",
-                sourceLocale: "en-US",
-                source: "This string’s contents do not contain quotes in it.",
-                targetLocale: "fr-FR",
-                target: "L’expression ne contient pas de guillemets.",
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x/y"
+        const resource = new ResourceString({
+            key: "quote.test",
+            sourceLocale: "en-US",
+            source: "This string’s contents do not contain quotes in it.",
+            targetLocale: "fr-FR",
+            target: "L’expression ne contient pas de guillemets.",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
         });
         test.ok(!actual);
 
@@ -712,17 +762,19 @@ export const testResourceQuoteStyle = {
         const rule = new ResourceQuoteStyle();
         test.ok(rule);
 
-        const actual = rule.match({
-            locale: "fr-FR",
-            resource: new ResourceString({
-                key: "quote.test",
-                sourceLocale: "en-US",
-                source: "These strings' contents do not contain quotes in it.",
-                targetLocale: "fr-FR",
-                target: "L'expressions ne contient pas de guillemets.",
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x/y"
+        const resource = new ResourceString({
+            key: "quote.test",
+            sourceLocale: "en-US",
+            source: "These strings' contents do not contain quotes in it.",
+            targetLocale: "fr-FR",
+            target: "L'expressions ne contient pas de guillemets.",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
         });
         test.ok(!actual);
 

--- a/test/testResourceTargetChecker.js
+++ b/test/testResourceTargetChecker.js
@@ -30,17 +30,19 @@ export const testResourceTargetChecker = {
         const rule = new ResourceTargetChecker(regexRules[2]);
         test.ok(rule);
 
-        const actual = rule.match({
-            locale: "ja-JP",
-            resource: new ResourceString({
-                key: "matcher.test",
-                sourceLocale: "en-US",
-                source: 'Upload to Box',
-                targetLocale: "ja-JP",
-                target: "Ｂｏｘにアップロード",
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x/y"
+        const resource = new ResourceString({
+            key: "matcher.test",
+            sourceLocale: "en-US",
+            source: 'Upload to Box',
+            targetLocale: "ja-JP",
+            target: "Ｂｏｘにアップロード",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
         });
         test.ok(actual);
         test.equal(actual.length, 1);
@@ -50,7 +52,7 @@ export const testResourceTargetChecker = {
         test.equal(actual[0].description, "The full-width characters 'Ｂｏｘ' are not allowed in the target string. Use ASCII letters instead.");
         test.equal(actual[0].highlight, "Target: <e0>Ｂｏｘ</e0>にアップロード");
         test.equal(actual[0].source, 'Upload to Box');
-        test.equal(actual[0].pathName, "x/y");
+        test.equal(actual[0].pathName, "a/b/c.xliff");
 
         test.done();
     },
@@ -61,21 +63,23 @@ export const testResourceTargetChecker = {
         const rule = new ResourceTargetChecker(regexRules[2]);
         test.ok(rule);
 
-        const actual = rule.match({
-            locale: "ja-JP",
-            resource: new ResourceArray({
-                key: "matcher.test",
-                sourceLocale: "en-US",
-                source: [
-                    'Upload to Box'
-                ],
-                targetLocale: "ja-JP",
-                target: [
-                    "Ｂｏｘにアップロード"
-                ],
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x/y"
+        const resource = new ResourceArray({
+            key: "matcher.test",
+            sourceLocale: "en-US",
+            source: [
+                'Upload to Box'
+            ],
+            targetLocale: "ja-JP",
+            target: [
+                "Ｂｏｘにアップロード"
+            ],
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource()[0],
+            target: resource.getTarget()[0],
+            resource,
+            file: "a/b/c.xliff"
         });
         test.ok(actual);
         test.equal(actual.length, 1);
@@ -85,7 +89,7 @@ export const testResourceTargetChecker = {
         test.equal(actual[0].description, "The full-width characters 'Ｂｏｘ' are not allowed in the target string. Use ASCII letters instead.");
         test.equal(actual[0].highlight, "Target: <e0>Ｂｏｘ</e0>にアップロード");
         test.equal(actual[0].source, 'Upload to Box');
-        test.equal(actual[0].pathName, "x/y");
+        test.equal(actual[0].pathName, "a/b/c.xliff");
 
         test.done();
     },
@@ -96,22 +100,24 @@ export const testResourceTargetChecker = {
         const rule = new ResourceTargetChecker(regexRules[2]);
         test.ok(rule);
 
-        const actual = rule.match({
-            locale: "ja-JP",
-            resource: new ResourcePlural({
-                key: "matcher.test",
-                sourceLocale: "en-US",
-                source: {
-                    one: 'Upload it',
-                    other: 'Upload to Box'
-                },
-                targetLocale: "ja-JP",
-                target: {
-                    other: "Ｂｏｘにアップロード"
-                },
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x/y"
+        const resource = new ResourcePlural({
+            key: "matcher.test",
+            sourceLocale: "en-US",
+            source: {
+                one: 'Upload it',
+                other: 'Upload to Box'
+            },
+            targetLocale: "ja-JP",
+            target: {
+                other: "Ｂｏｘにアップロード"
+            },
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource().other,
+            target: resource.getTarget().other,
+            resource,
+            file: "a/b/c.xliff"
         });
         test.ok(actual);
         test.equal(actual.length, 1);
@@ -121,7 +127,7 @@ export const testResourceTargetChecker = {
         test.equal(actual[0].description, "The full-width characters 'Ｂｏｘ' are not allowed in the target string. Use ASCII letters instead.");
         test.equal(actual[0].highlight, "Target: <e0>Ｂｏｘ</e0>にアップロード");
         test.equal(actual[0].source, 'Upload to Box');
-        test.equal(actual[0].pathName, "x/y");
+        test.equal(actual[0].pathName, "a/b/c.xliff");
 
         test.done();
     },
@@ -132,17 +138,19 @@ export const testResourceTargetChecker = {
         const rule = new ResourceTargetChecker(regexRules[2]);
         test.ok(rule);
 
-        const actual = rule.match({
-            locale: "ja-JP",
-            resource: new ResourceString({
-                key: "matcher.test",
-                sourceLocale: "en-US",
-                source: 'Upload to Box',
-                targetLocale: "ja-JP",
-                target: "Boxにアップロード",
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x/y"
+        const resource = new ResourceString({
+            key: "matcher.test",
+            sourceLocale: "en-US",
+            source: 'Upload to Box',
+            targetLocale: "ja-JP",
+            target: "Boxにアップロード",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
         });
         test.ok(!actual);
 
@@ -155,21 +163,23 @@ export const testResourceTargetChecker = {
         const rule = new ResourceTargetChecker(regexRules[2]);
         test.ok(rule);
 
-        const actual = rule.match({
-            locale: "ja-JP",
-            resource: new ResourceArray({
-                key: "matcher.test",
-                sourceLocale: "en-US",
-                source: [
-                    'Upload to Box'
-                ],
-                targetLocale: "ja-JP",
-                target: [
-                    "Boxにアップロード"
-                ],
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x/y"
+        const resource = new ResourceArray({
+            key: "matcher.test",
+            sourceLocale: "en-US",
+            source: [
+                'Upload to Box'
+            ],
+            targetLocale: "ja-JP",
+            target: [
+                "Boxにアップロード"
+            ],
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
         });
         test.ok(!actual);
 
@@ -182,22 +192,24 @@ export const testResourceTargetChecker = {
         const rule = new ResourceTargetChecker(regexRules[2]);
         test.ok(rule);
 
-        const actual = rule.match({
-            locale: "ja-JP",
-            resource: new ResourceArray({
-                key: "matcher.test",
-                sourceLocale: "en-US",
-                source: {
-                    one: "Upload it",
-                    other: "Upload to Box"
-                },
-                targetLocale: "ja-JP",
-                target: {
-                    other: "Boxにアップロード"
-                },
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x/y"
+        const resource = new ResourceArray({
+            key: "matcher.test",
+            sourceLocale: "en-US",
+            source: {
+                one: "Upload it",
+                other: "Upload to Box"
+            },
+            targetLocale: "ja-JP",
+            target: {
+                other: "Boxにアップロード"
+            },
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
         });
         test.ok(!actual);
 
@@ -210,17 +222,19 @@ export const testResourceTargetChecker = {
         const rule = new ResourceTargetChecker(regexRules[2]);
         test.ok(rule);
 
-        const actual = rule.match({
-            locale: "ja-JP",
-            resource: new ResourceString({
-                key: "matcher.test",
-                sourceLocale: "en-US",
-                source: 'Upload to Box',
-                targetLocale: "ja-JP",
-                target: "プロＢｏｘにアップロードＢｏｘ",
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x/y"
+        const resource = new ResourceString({
+            key: "matcher.test",
+            sourceLocale: "en-US",
+            source: 'Upload to Box',
+            targetLocale: "ja-JP",
+            target: "プロＢｏｘにアップロードＢｏｘ",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
         });
         test.ok(actual);
         test.equal(actual.length, 2);
@@ -230,14 +244,14 @@ export const testResourceTargetChecker = {
         test.equal(actual[0].description, "The full-width characters 'Ｂｏｘ' are not allowed in the target string. Use ASCII letters instead.");
         test.equal(actual[0].highlight, "Target: プロ<e0>Ｂｏｘ</e0>にアップロードＢｏｘ");
         test.equal(actual[0].source, 'Upload to Box');
-        test.equal(actual[0].pathName, "x/y");
+        test.equal(actual[0].pathName, "a/b/c.xliff");
 
         test.equal(actual[1].severity, "error");
         test.equal(actual[1].id, "matcher.test");
         test.equal(actual[1].description, "The full-width characters 'Ｂｏｘ' are not allowed in the target string. Use ASCII letters instead.");
         test.equal(actual[1].highlight, "Target: プロＢｏｘにアップロード<e0>Ｂｏｘ</e0>");
         test.equal(actual[1].source, 'Upload to Box');
-        test.equal(actual[1].pathName, "x/y");
+        test.equal(actual[1].pathName, "a/b/c.xliff");
 
         test.done();
     },
@@ -248,17 +262,19 @@ export const testResourceTargetChecker = {
         const rule = new ResourceTargetChecker(regexRules[3]);
         test.ok(rule);
 
-        const actual = rule.match({
-            locale: "ja-JP",
-            resource: new ResourceString({
-                key: "matcher.test",
-                sourceLocale: "en-US",
-                source: 'Box12345',
-                targetLocale: "ja-JP",
-                target: "Box１２３４５",
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x/y"
+        const resource = new ResourceString({
+            key: "matcher.test",
+            sourceLocale: "en-US",
+            source: 'Box12345',
+            targetLocale: "ja-JP",
+            target: "Box１２３４５",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
         });
         test.ok(actual);
         test.equal(actual.length, 1);
@@ -268,7 +284,7 @@ export const testResourceTargetChecker = {
         test.equal(actual[0].description, "The full-width characters '１２３４５' are not allowed in the target string. Use ASCII digits instead.");
         test.equal(actual[0].highlight, "Target: Box<e0>１２３４５</e0>");
         test.equal(actual[0].source, 'Box12345');
-        test.equal(actual[0].pathName, "x/y");
+        test.equal(actual[0].pathName, "a/b/c.xliff");
 
         test.done();
     },
@@ -279,17 +295,19 @@ export const testResourceTargetChecker = {
         const rule = new ResourceTargetChecker(regexRules[3]);
         test.ok(rule);
 
-        const actual = rule.match({
-            locale: "ja-JP",
-            resource: new ResourceString({
-                key: "matcher.test",
-                sourceLocale: "en-US",
-                source: 'Upload to Box',
-                targetLocale: "ja-JP",
-                target: "Boxにアップロード",
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x/y"
+        const resource = new ResourceString({
+            key: "matcher.test",
+            sourceLocale: "en-US",
+            source: 'Upload to Box',
+            targetLocale: "ja-JP",
+            target: "Boxにアップロード",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
         });
         test.ok(!actual);
 
@@ -302,17 +320,19 @@ export const testResourceTargetChecker = {
         const rule = new ResourceTargetChecker(regexRules[3]);
         test.ok(rule);
 
-        const actual = rule.match({
-            locale: "ja-JP",
-            resource: new ResourceString({
-                key: "matcher.test",
-                sourceLocale: "en-US",
-                source: '12345Box12345',
-                targetLocale: "ja-JP",
-                target: "５４３２１Box１２３４５",
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x/y"
+        const resource = new ResourceString({
+            key: "matcher.test",
+            sourceLocale: "en-US",
+            source: '12345Box12345',
+            targetLocale: "ja-JP",
+            target: "５４３２１Box１２３４５",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
         });
         test.ok(actual);
         test.equal(actual.length, 2);
@@ -322,14 +342,14 @@ export const testResourceTargetChecker = {
         test.equal(actual[0].description, "The full-width characters '５４３２１' are not allowed in the target string. Use ASCII digits instead.");
         test.equal(actual[0].highlight, "Target: <e0>５４３２１</e0>Box１２３４５");
         test.equal(actual[0].source, '12345Box12345');
-        test.equal(actual[0].pathName, "x/y");
+        test.equal(actual[0].pathName, "a/b/c.xliff");
 
         test.equal(actual[1].severity, "error");
         test.equal(actual[1].id, "matcher.test");
         test.equal(actual[1].description, "The full-width characters '１２３４５' are not allowed in the target string. Use ASCII digits instead.");
         test.equal(actual[1].highlight, "Target: ５４３２１Box<e0>１２３４５</e0>");
         test.equal(actual[1].source, '12345Box12345');
-        test.equal(actual[1].pathName, "x/y");
+        test.equal(actual[1].pathName, "a/b/c.xliff");
 
         test.done();
     },
@@ -344,20 +364,21 @@ export const testResourceTargetChecker = {
         test.ok(rule);
 
         for (const symbol of illegalPunctuations) {
-            const matchSubject = {
-                locale: "ja-JP",
-                resource: new ResourceString({
-                    key: "matcher.test",
-                    sourceLocale: "en-US",
-                    source: `test${symbol} test`,
-                    targetLocale: "ja-JP",
-                    target: `テスト${symbol} テスト`,
-                    pathName: "a/b/c.xliff",
-                }),
-                file: "x/y",
-            };
+            const resource = new ResourceString({
+                key: "matcher.test",
+                sourceLocale: "en-US",
+                source: `test${symbol} test`,
+                targetLocale: "ja-JP",
+                target: `テスト${symbol} テスト`,
+                pathName: "a/b/c.xliff",
+            });
 
-            const actual = rule.match(matchSubject);
+            const actual = rule.matchString({
+                source: resource.getSource(),
+                target: resource.getTarget(),
+                resource,
+                file: "a/b/c.xliff"
+            });
             test.ok(actual);
             test.equal(actual.length, 1);
 
@@ -369,7 +390,7 @@ export const testResourceTargetChecker = {
             test.equal(actual[0].highlight, `Target: テスト<e0>${symbol}</e0> テスト`);
             test.equal(actual[0].id, "matcher.test");
             test.equal(actual[0].source, `test${symbol} test`);
-            test.equal(actual[0].pathName, "x/y");
+            test.equal(actual[0].pathName, "a/b/c.xliff");
         }
 
         test.done();
@@ -383,17 +404,19 @@ export const testResourceTargetChecker = {
         );
         test.ok(rule);
 
-        const actual = rule.match({
-            locale: "ja-JP",
-            resource: new ResourceString({
-                key: "matcher.test",
-                sourceLocale: "en-US",
-                source: "Really? Yes! 100%",
-                targetLocale: "ja-JP",
-                target: "本当? はい! 100%",
-                pathName: "a/b/c.xliff",
-            }),
-            file: "x/y",
+        const resource = new ResourceString({
+            key: "matcher.test",
+            sourceLocale: "en-US",
+            source: "Really? Yes! 100%",
+            targetLocale: "ja-JP",
+            target: "本当? はい! 100%",
+            pathName: "a/b/c.xliff",
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff",
         });
         test.ok(!actual);
 
@@ -408,19 +431,20 @@ export const testResourceTargetChecker = {
         );
         test.ok(rule);
 
-        const matchSubject = {
-            locale: "ja-JP",
-            resource: new ResourceString({
-                key: "matcher.test",
-                sourceLocale: "en-US",
-                source: "Really? Yes! 100%",
-                targetLocale: "ja-JP",
-                target: "本当？ はい！ 100％",
-                pathName: "a/b/c.xliff",
-            }),
-            file: "x/y",
-        };
-        const actual = rule.match(matchSubject);
+        const resource = new ResourceString({
+            key: "matcher.test",
+            sourceLocale: "en-US",
+            source: "Really? Yes! 100%",
+            targetLocale: "ja-JP",
+            target: "本当？ はい！ 100％",
+            pathName: "a/b/c.xliff",
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
         test.ok(actual);
         test.equal(actual.length, 3);
 
@@ -428,7 +452,7 @@ export const testResourceTargetChecker = {
             test.equal(a.severity, "error");
             test.equal(a.id, "matcher.test");
             test.equal(a.source, "Really? Yes! 100%");
-            test.equal(a.pathName, "x/y");
+            test.equal(a.pathName, "a/b/c.xliff");
         }
 
         test.equal(
@@ -460,25 +484,26 @@ export const testResourceTargetChecker = {
         );
         test.ok(rule);
 
-        const subject = {
-            locale: "ja-JP",
-            resource: new ResourceString({
-                key: "matcher.test",
-                sourceLocale: "en-US",
-                source: "Communication",
-                targetLocale: "ja-JP",
-                target: "ｺﾐｭﾆｹｰｼｮﾝ",
-                pathName: "a/b/c.xliff",
-            }),
-            file: "x/y",
-        };
+        const resource = new ResourceString({
+            key: "matcher.test",
+            sourceLocale: "en-US",
+            source: "Communication",
+            targetLocale: "ja-JP",
+            target: "ｺﾐｭﾆｹｰｼｮﾝ",
+            pathName: "a/b/c.xliff",
+        });
 
-        const result = rule.match(subject);
+        const result = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
         test.deepEqual(result, [new Result({
             rule,
             severity: "warning",
             locale: "ja-JP",
-            pathName: "x/y",
+            pathName: "a/b/c.xliff",
             source: "Communication",
             id: "matcher.test",
             description: "The half-width kana characters are not allowed in the target string. Use full-width characters.",
@@ -516,24 +541,25 @@ export const testResourceTargetChecker = {
         test.ok(rule);
 
         for (const symbol of illegalCharacters) {
-            const subject = {
-                locale: "ja-JP",
-                resource: new ResourceString({
-                    key: "matcher.test",
-                    sourceLocale: "en-US",
-                    source: `test${symbol}test`,
-                    targetLocale: "ja-JP",
-                    target: `テスト${symbol}テスト`,
-                    pathName: "a/b/c.xliff",
-                }),
-                file: "x/y",
-            };
+            const resource = new ResourceString({
+                key: "matcher.test",
+                sourceLocale: "en-US",
+                source: `test${symbol}test`,
+                targetLocale: "ja-JP",
+                target: `テスト${symbol}テスト`,
+                pathName: "a/b/c.xliff",
+            });
 
-            const result = rule.match(subject);
+            const result = rule.matchString({
+                source: resource.getSource(),
+                target: resource.getTarget(),
+                resource,
+                file: "a/b/c.xliff"
+            });
             test.deepEqual(result, [new Result({
                 rule,
                 severity: "warning",
-                pathName: "x/y",
+                pathName: "a/b/c.xliff",
                 locale: "ja-JP",
                 source: `test${symbol}test`,
                 id: "matcher.test",
@@ -577,24 +603,25 @@ export const testResourceTargetChecker = {
 
         for (const symbol of applicableCharacters) {
             const illegalSequence = symbol + " ";
-            const subject = {
-                locale: "ja-JP",
-                resource: new ResourceString({
-                    key: "matcher.test",
-                    sourceLocale: "en-US",
-                    source: `test${illegalSequence}test`,
-                    targetLocale: "ja-JP",
-                    target: `テスト${illegalSequence}テスト`,
-                    pathName: "a/b/c.xliff",
-                }),
-                file: "x/y",
-            };
+            const resource = new ResourceString({
+                key: "matcher.test",
+                sourceLocale: "en-US",
+                source: `test${illegalSequence}test`,
+                targetLocale: "ja-JP",
+                target: `テスト${illegalSequence}テスト`,
+                pathName: "a/b/c.xliff",
+            });
 
-            const result = rule.match(subject);
+            const result = rule.matchString({
+                source: resource.getSource(),
+                target: resource.getTarget(),
+                resource,
+                file: "a/b/c.xliff"
+            });
             test.deepEqual(result, [new Result({
                 rule,
                 severity: "warning",
-                pathName: "x/y",
+                pathName: "a/b/c.xliff",
                 locale: "ja-JP",
                 source: `test${illegalSequence}test`,
                 id: "matcher.test",
@@ -638,24 +665,25 @@ export const testResourceTargetChecker = {
 
         for (const symbol of applicableCharacters) {
             const illegalSequence = " " + symbol;
-            const subject = {
-                locale: "ja-JP",
-                resource: new ResourceString({
-                    key: "matcher.test",
-                    sourceLocale: "en-US",
-                    source: `test${illegalSequence}test`,
-                    targetLocale: "ja-JP",
-                    target: `テスト${illegalSequence}テスト`,
-                    pathName: "a/b/c.xliff",
-                }),
-                file: "x/y",
-            };
+            const resource = new ResourceString({
+                key: "matcher.test",
+                sourceLocale: "en-US",
+                source: `test${illegalSequence}test`,
+                targetLocale: "ja-JP",
+                target: `テスト${illegalSequence}テスト`,
+                pathName: "a/b/c.xliff",
+            });
 
-            const result = rule.match(subject);
+            const result = rule.matchString({
+                source: resource.getSource(),
+                target: resource.getTarget(),
+                resource,
+                file: "a/b/c.xliff"
+            });
             test.deepEqual(result, [new Result({
                 rule,
                 severity: "warning",
-                pathName: "x/y",
+                pathName: "a/b/c.xliff",
                 locale: "ja-JP",
                 source: `test${illegalSequence}test`,
                 id: "matcher.test",
@@ -675,25 +703,26 @@ export const testResourceTargetChecker = {
         );
         test.ok(rule);
 
-        const subject = {
-            locale: "ja-JP",
-            resource: new ResourceString({
-                key: "matcher.test",
-                sourceLocale: "en-US",
-                source: "Box Embed Widget",
-                targetLocale: "ja-JP",
-                target: "Box 埋め込みウィジェット",
-                pathName: "a/b/c.xliff",
-            }),
-            file: "x/y",
-        };
+        const resource = new ResourceString({
+            key: "matcher.test",
+            sourceLocale: "en-US",
+            source: "Box Embed Widget",
+            targetLocale: "ja-JP",
+            target: "Box 埋め込みウィジェット",
+            pathName: "a/b/c.xliff",
+        });
 
-        const result = rule.match(subject);
+        const result = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
         test.deepEqual(result, [new Result({
             rule,
             severity: "warning",
             locale: "ja-JP",
-            pathName: "x/y",
+            pathName: "a/b/c.xliff",
             source: "Box Embed Widget",
             id: "matcher.test",
             description: 'The space character is not allowed in the target string. Remove the space character.',
@@ -711,17 +740,19 @@ export const testResourceTargetChecker = {
         );
         test.ok(rule);
 
-        const actual = rule.match({
-            locale: "ja-JP",
-            resource: new ResourceString({
-                key: "matcher.test",
-                sourceLocale: "en-US",
-                source: "Box Embed Widget",
-                targetLocale: "ja-JP",
-                target: "EXIFおよびXMPメタデータ",
-                pathName: "a/b/c.xliff",
-            }),
-            file: "x/y",
+        const resource = new ResourceString({
+            key: "matcher.test",
+            sourceLocale: "en-US",
+            source: "Box Embed Widget",
+            targetLocale: "ja-JP",
+            target: "EXIFおよびXMPメタデータ",
+            pathName: "a/b/c.xliff",
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
         });
         test.ok(!actual);
    

--- a/test/testRules.js
+++ b/test/testRules.js
@@ -25,7 +25,7 @@ import ResourceCompleteness from "../src/rules/ResourceCompleteness.js";
 import ResourceDNTTerms from '../src/rules/ResourceDNTTerms.js';
 import ResourceNoTranslation from '../src/rules/ResourceNoTranslation.js';
 
-import { Result } from 'i18nlint-common';
+import { Result, IntermediateRepresentation } from 'i18nlint-common';
 
 export const testRules = {
     testResourceICUPluralsMatchNoError: function(test) {
@@ -34,17 +34,19 @@ export const testRules = {
         const rule = new ResourceICUPlurals();
         test.ok(rule);
 
-        const actual = rule.match({
-            locale: "de-DE",
-            resource: new ResourceString({
-                key: "plural.test",
-                sourceLocale: "en-US",
-                source: '{count, plural, one {This is singular} other {This is plural}}',
-                targetLocale: "de-DE",
-                target: "{count, plural, one {Dies ist einzigartig} other {Dies ist mehrerartig}}",
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x/y"
+        const resource = new ResourceString({
+            key: "plural.test",
+            sourceLocale: "en-US",
+            source: '{count, plural, one {This is singular} other {This is plural}}',
+            targetLocale: "de-DE",
+            target: "{count, plural, one {Dies ist einzigartig} other {Dies ist mehrerartig}}",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
         });
         test.ok(!actual);
 
@@ -57,17 +59,19 @@ export const testRules = {
         const rule = new ResourceICUPlurals();
         test.ok(rule);
 
-        const actual = rule.match({
-            locale: "de-DE",
-            resource: new ResourceString({
-                key: "plural.test",
-                sourceLocale: "en-US",
-                source: '{count, plural, one {{total, plural, one {There is {count} of {total} item available} other {There is {count} of {total} items available}}} other {{total, plural, one {There are {count} of {total} item available} other {There are {count} of {total} items available}}}}',
-                targetLocale: "de-DE",
-                target: "{count, plural, one {{total, plural, one {Es gibt {count} von {total} Arkitel verfügbar} other {Es gibt {count} von {total} Arkitel verfügbar}}} other {{total, plural, one {Es gibt {count} von {total} Arkitel verfügbar} other {Es gibt {count} von {total} Arkitel verfügbar}}}}",
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x/y"
+        const resource = new ResourceString({
+            key: "plural.test",
+            sourceLocale: "en-US",
+            source: '{count, plural, one {{total, plural, one {There is {count} of {total} item available} other {There is {count} of {total} items available}}} other {{total, plural, one {There are {count} of {total} item available} other {There are {count} of {total} items available}}}}',
+            targetLocale: "de-DE",
+            target: "{count, plural, one {{total, plural, one {Es gibt {count} von {total} Arkitel verfügbar} other {Es gibt {count} von {total} Arkitel verfügbar}}} other {{total, plural, one {Es gibt {count} von {total} Arkitel verfügbar} other {Es gibt {count} von {total} Arkitel verfügbar}}}}",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
         });
         test.ok(!actual);
 
@@ -80,43 +84,45 @@ export const testRules = {
         const rule = new ResourceICUPlurals();
         test.ok(rule);
 
-        const actual = rule.match({
-            locale: "de-DE",
-            resource: new ResourceString({
-                key: "plural.test",
-                sourceLocale: "en-US",
-                source: `{count, plural,
-                    one {
-                        {total, plural,
-                            one {There is {count} of {total} item available}
-                            other {There is {count} of {total} items available}
-                        }
+        const resource = new ResourceString({
+            key: "plural.test",
+            sourceLocale: "en-US",
+            source: `{count, plural,
+                one {
+                    {total, plural,
+                        one {There is {count} of {total} item available}
+                        other {There is {count} of {total} items available}
                     }
-                    other {
-                        {total, plural,
-                            one {There are {count} of {total} item available}
-                            other {There are {count} of {total} items available}
-                        }
+                }
+                other {
+                    {total, plural,
+                        one {There are {count} of {total} item available}
+                        other {There are {count} of {total} items available}
                     }
-                }`,
-                targetLocale: "de-DE",
-                target: `{count, plural,
-                    one {
-                        {total, plural,
-                            one {Es gibt {count} von {total} Arkitel verfügbar}
-                            other {Es gibt {count} von {total} Arkitel verfügbar}
-                        }
+                }
+            }`,
+            targetLocale: "de-DE",
+            target: `{count, plural,
+                one {
+                    {total, plural,
+                        one {Es gibt {count} von {total} Arkitel verfügbar}
+                        other {Es gibt {count} von {total} Arkitel verfügbar}
                     }
-                    other {
-                        {total, plural,
-                            one {Es gibt {count} von {total} Arkitel verfügbar}
-                            other {Es gibt {count} von {total} Arkitel verfügbar}
-                        }
+                }
+                other {
+                    {total, plural,
+                        one {Es gibt {count} von {total} Arkitel verfügbar}
+                        other {Es gibt {count} von {total} Arkitel verfügbar}
                     }
-                }`,
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x/y"
+                }
+            }`,
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
         });
         test.ok(!actual);
 
@@ -129,17 +135,19 @@ export const testRules = {
         const rule = new ResourceICUPlurals();
         test.ok(rule);
 
-        const actual = rule.match({
-            locale: "de-DE",
-            resource: new ResourceString({
-                key: "plural.test",
-                sourceLocale: "en-US",
-                source: '{count, plural, one {This is singular} other {This is plural}}',
-                targetLocale: "de-DE",
-                target: "{count, plural, one {{Dies ist einzigartig} other {Dies ist mehrerartig}}",
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x/y"
+        const resource = new ResourceString({
+            key: "plural.test",
+            sourceLocale: "en-US",
+            source: '{count, plural, one {This is singular} other {This is plural}}',
+            targetLocale: "de-DE",
+            target: "{count, plural, one {{Dies ist einzigartig} other {Dies ist mehrerartig}}",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
         });
         const expected = new Result({
             severity: "error",
@@ -149,7 +157,7 @@ export const testRules = {
             highlight: 'Target: {count, plural, one {{Dies <e0>ist einzigartig} other {Dies ist mehrerartig}}</e0>',
             rule,
             locale: "de-DE",
-            pathName: "x/y"
+            pathName: "a/b/c.xliff"
         });
         test.deepEqual(actual, expected);
 
@@ -162,17 +170,19 @@ export const testRules = {
         const rule = new ResourceICUPlurals();
         test.ok(rule);
 
-        const actual = rule.match({
-            locale: "de-DE",
-            resource: new ResourceString({
-                key: "plural.test",
-                sourceLocale: "en-US",
-                source: '{count, plural, one {This is singular} other {This is plural}}',
-                targetLocale: "de-DE",
-                target: "{count, plural, one {Dies ist einzigartig} other {Dies ist mehrerartig}",
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x/y"
+        const resource = new ResourceString({
+            key: "plural.test",
+            sourceLocale: "en-US",
+            source: '{count, plural, one {This is singular} other {This is plural}}',
+            targetLocale: "de-DE",
+            target: "{count, plural, one {Dies ist einzigartig} other {Dies ist mehrerartig}",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
         });
         const expected = new Result({
             severity: "error",
@@ -182,7 +192,7 @@ export const testRules = {
             highlight: 'Target: {count, plural, one {Dies ist einzigartig} other {Dies ist mehrerartig}<e0></e0>',
             rule,
             locale: "de-DE",
-            pathName: "x/y"
+            pathName: "a/b/c.xliff"
         });
         test.deepEqual(actual, expected);
 
@@ -195,17 +205,19 @@ export const testRules = {
         const rule = new ResourceICUPlurals();
         test.ok(rule);
 
-        const actual = rule.match({
-            locale: "de-DE",
-            resource: new ResourceString({
-                key: "plural.test",
-                sourceLocale: "en-US",
-                source: '{count, plural, one {This is singular} other {This is plural}}',
-                targetLocale: "de-DE",
-                target: "{count, plural, eins {Dies ist einzigartig} andere {Dies ist mehrerartig}}",
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x/y"
+        const resource = new ResourceString({
+            key: "plural.test",
+            sourceLocale: "en-US",
+            source: '{count, plural, one {This is singular} other {This is plural}}',
+            targetLocale: "de-DE",
+            target: "{count, plural, eins {Dies ist einzigartig} andere {Dies ist mehrerartig}}",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
         });
         const expected = new Result({
             severity: "error",
@@ -215,7 +227,7 @@ export const testRules = {
             highlight: 'Target: {count, plural, eins {Dies ist einzigartig} andere {Dies ist mehrerartig}<e0>}</e0>',
             rule,
             locale: "de-DE",
-            pathName: "x/y"
+            pathName: "a/b/c.xliff"
         });
         test.deepEqual(actual, expected);
 
@@ -228,17 +240,19 @@ export const testRules = {
         const rule = new ResourceICUPlurals();
         test.ok(rule);
 
-        const actual = rule.match({
-            locale: "ru-RU",
-            resource: new ResourceString({
-                key: "plural.test",
-                sourceLocale: "en-US",
-                source: '{count, plural, one {This is singular} other {This is plural}}',
-                targetLocale: "ru-RU",
-                target: "{count, plural, one {Это единственное число} other {это множественное число}}",
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x/y"
+        const resource = new ResourceString({
+            key: "plural.test",
+            sourceLocale: "en-US",
+            source: '{count, plural, one {This is singular} other {This is plural}}',
+            targetLocale: "ru-RU",
+            target: "{count, plural, one {Это единственное число} other {это множественное число}}",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
         });
         const expected = new Result({
             severity: "error",
@@ -248,7 +262,7 @@ export const testRules = {
             highlight: 'Target: {count, plural, one {Это единственное число} other {это множественное число}}<e0></e0>',
             rule,
             locale: "ru-RU",
-            pathName: "x/y"
+            pathName: "a/b/c.xliff"
         });
         test.deepEqual(actual, expected);
 
@@ -261,17 +275,17 @@ export const testRules = {
         const rule = new ResourceICUPlurals();
         test.ok(rule);
 
+        const resource = new ResourceString({
+            key: "plural.test",
+            sourceLocale: "en-US",
+            source: '{count, plural, other {This is plural}}',
+            targetLocale: "ru-RU",
+            target: "{count, plural, one {Это единственное число} few {это множественное число} other {это множественное число}}",
+            pathName: "a/b/c.xliff"
+        });
         const actual = rule.match({
             locale: "ru-RU",
-            resource: new ResourceString({
-                key: "plural.test",
-                sourceLocale: "en-US",
-                source: '{count, plural, other {This is plural}}',
-                targetLocale: "ru-RU",
-                target: "{count, plural, one {Это единственное число} few {это множественное число} other {это множественное число}}",
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x/y"
+            file: "a/b/c.xliff"
         });
         // this rule does not test for problems in the source string
         test.ok(!actual);
@@ -285,17 +299,19 @@ export const testRules = {
         const rule = new ResourceICUPlurals();
         test.ok(rule);
 
-        const actual = rule.match({
-            locale: "de-DE",
-            resource: new ResourceString({
-                key: "plural.test",
-                sourceLocale: "en-US",
-                source: '{count, plural, one {This is singular} other {This is plural}}',
-                targetLocale: "de-DE",
-                target: "{count, plural, one {Dies ist einzigartig} few {This is few} other {Dies ist mehrerartig}}",
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x/y"
+        const resource = new ResourceString({
+            key: "plural.test",
+            sourceLocale: "en-US",
+            source: '{count, plural, one {This is singular} other {This is plural}}',
+            targetLocale: "de-DE",
+            target: "{count, plural, one {Dies ist einzigartig} few {This is few} other {Dies ist mehrerartig}}",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
         });
         const expected = new Result({
             severity: "warning",
@@ -303,7 +319,7 @@ export const testRules = {
             id: "plural.test",
             highlight: 'Target: {count, plural, one {Dies ist einzigartig} few {This is few} other {Dies ist mehrerartig}}<e0></e0>',
             rule,
-            pathName: "x/y",
+            pathName: "a/b/c.xliff",
             locale: "de-DE",
             source: '{count, plural, one {This is singular} other {This is plural}}'
         });
@@ -318,17 +334,19 @@ export const testRules = {
         const rule = new ResourceICUPlurals();
         test.ok(rule);
 
-        const actual = rule.match({
-            locale: "de-DE",
-            resource: new ResourceString({
-                key: "plural.test",
-                sourceLocale: "en-US",
-                source: '{count, plural, =1 {This is one} one {This is singular} other {This is plural}}',
-                targetLocale: "de-DE",
-                target: "{count, plural, =1 {Dies is eins} one {Dies ist einzigartig} other {Dies ist mehrerartig}}",
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x/y"
+        const resource = new ResourceString({
+            key: "plural.test",
+            sourceLocale: "en-US",
+            source: '{count, plural, =1 {This is one} one {This is singular} other {This is plural}}',
+            targetLocale: "de-DE",
+            target: "{count, plural, =1 {Dies is eins} one {Dies ist einzigartig} other {Dies ist mehrerartig}}",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
         });
         test.ok(!actual);
 
@@ -341,17 +359,19 @@ export const testRules = {
         const rule = new ResourceICUPlurals();
         test.ok(rule);
 
-        const actual = rule.match({
-            locale: "de-DE",
-            resource: new ResourceString({
-                key: "plural.test",
-                sourceLocale: "en-US",
-                source: '{count, plural, =1 {This is one} one {This is singular} other {This is plural}}',
-                targetLocale: "de-DE",
-                target: "{count, plural, one {Dies ist einzigartig} other {Dies ist mehrerartig}}",
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x/y"
+        const resource = new ResourceString({
+            key: "plural.test",
+            sourceLocale: "en-US",
+            source: '{count, plural, =1 {This is one} one {This is singular} other {This is plural}}',
+            targetLocale: "de-DE",
+            target: "{count, plural, one {Dies ist einzigartig} other {Dies ist mehrerartig}}",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
         });
         const expected = new Result({
             severity: "error",
@@ -359,7 +379,7 @@ export const testRules = {
             id: "plural.test",
             highlight: 'Target: {count, plural, one {Dies ist einzigartig} other {Dies ist mehrerartig}}<e0></e0>',
             rule,
-            pathName: "x/y",
+            pathName: "a/b/c.xliff",
             locale: "de-DE",
             source: '{count, plural, =1 {This is one} one {This is singular} other {This is plural}}'
         });
@@ -374,95 +394,97 @@ export const testRules = {
         const rule = new ResourceICUPlurals();
         test.ok(rule);
 
-        const actual = rule.match({
-            locale: "ru-RU",
-            resource: new ResourceString({
-                key: "plural.test",
-                sourceLocale: "en-US",
-                source: `{count, plural,
-                    one {
-                        {total, plural,
-                            one {There is {count} of {total} item available}
-                            other {There is {count} of {total} items available}
-                        }
+        const resource = new ResourceString({
+            key: "plural.test",
+            sourceLocale: "en-US",
+            source: `{count, plural,
+                one {
+                    {total, plural,
+                        one {There is {count} of {total} item available}
+                        other {There is {count} of {total} items available}
                     }
-                    other {
-                        {total, plural,
-                            one {There are {count} of {total} item available}
-                            other {There are {count} of {total} items available}
-                        }
+                }
+                other {
+                    {total, plural,
+                        one {There are {count} of {total} item available}
+                        other {There are {count} of {total} items available}
                     }
-                }`,
-                targetLocale: "ru-RU",
-                target: `{count, plural,
-                    one {
-                        {total, plural,
-                            one {Есть {count} из {total} статьи}
-                            few {Есть {count} из {total} статей}
-                            other {Есть {count} из {total} статей}
-                        }
+                }
+            }`,
+            targetLocale: "ru-RU",
+            target: `{count, plural,
+                one {
+                    {total, plural,
+                        one {Есть {count} из {total} статьи}
+                        few {Есть {count} из {total} статей}
+                        other {Есть {count} из {total} статей}
                     }
-                    few {
-                        {total, plural,
-                            one {Есть {count} из {total} статьи}
-                            other {Есть {count} из {total} статей}
-                        }
+                }
+                few {
+                    {total, plural,
+                        one {Есть {count} из {total} статьи}
+                        other {Есть {count} из {total} статей}
                     }
-                    other {
-                        {total, plural,
-                            one {Есть {count} из {total} статьи}
-                            few {Есть {count} из {total} статей}
-                            other {Есть {count} из {total} статей}
-                        }
+                }
+                other {
+                    {total, plural,
+                        one {Есть {count} из {total} статьи}
+                        few {Есть {count} из {total} статей}
+                        other {Есть {count} из {total} статей}
                     }
-                }`,
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x/y"
+                }
+            }`,
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
         });
         const expected = new Result({
             severity: "error",
             description: "Missing plural categories in target string: few. Expecting these: one, few, other",
             id: "plural.test",
             highlight: 'Target: {count, plural,\n' +
-                '                    one {\n' +
-                '                        {total, plural,\n' +
-                '                            one {Есть {count} из {total} статьи}\n' +
-                '                            few {Есть {count} из {total} статей}\n' +
-                '                            other {Есть {count} из {total} статей}\n' +
-                '                        }\n' +
+                '                one {\n' +
+                '                    {total, plural,\n' +
+                '                        one {Есть {count} из {total} статьи}\n' +
+                '                        few {Есть {count} из {total} статей}\n' +
+                '                        other {Есть {count} из {total} статей}\n' +
                 '                    }\n' +
-                '                    few {\n' +
-                '                        {total, plural,\n' +
-                '                            one {Есть {count} из {total} статьи}\n' +
-                '                            other {Есть {count} из {total} статей}\n' +
-                '                        }\n' +
+                '                }\n' +
+                '                few {\n' +
+                '                    {total, plural,\n' +
+                '                        one {Есть {count} из {total} статьи}\n' +
+                '                        other {Есть {count} из {total} статей}\n' +
                 '                    }\n' +
-                '                    other {\n' +
-                '                        {total, plural,\n' +
-                '                            one {Есть {count} из {total} статьи}\n' +
-                '                            few {Есть {count} из {total} статей}\n' +
-                '                            other {Есть {count} из {total} статей}\n' +
-                '                        }\n' +
+                '                }\n' +
+                '                other {\n' +
+                '                    {total, plural,\n' +
+                '                        one {Есть {count} из {total} статьи}\n' +
+                '                        few {Есть {count} из {total} статей}\n' +
+                '                        other {Есть {count} из {total} статей}\n' +
                 '                    }\n' +
-                '                }<e0></e0>',
+                '                }\n' +
+                '            }<e0></e0>',
             rule,
-            pathName: "x/y",
+            pathName: "a/b/c.xliff",
             locale: "ru-RU",
             source: `{count, plural,
-                    one {
-                        {total, plural,
-                            one {There is {count} of {total} item available}
-                            other {There is {count} of {total} items available}
-                        }
+                one {
+                    {total, plural,
+                        one {There is {count} of {total} item available}
+                        other {There is {count} of {total} items available}
                     }
-                    other {
-                        {total, plural,
-                            one {There are {count} of {total} item available}
-                            other {There are {count} of {total} items available}
-                        }
+                }
+                other {
+                    {total, plural,
+                        one {There are {count} of {total} item available}
+                        other {There are {count} of {total} items available}
                     }
-                }`
+                }
+            }`
         });
         test.deepEqual(actual, expected);
 
@@ -475,50 +497,52 @@ export const testRules = {
         const rule = new ResourceICUPlurals();
         test.ok(rule);
 
-        const actual = rule.match({
-            locale: "ru-RU",
-            resource: new ResourceString({
-                key: "plural.test",
-                sourceLocale: "en-US",
-                source: `{count, plural,
-                    one {
-                        {total, plural,
-                            one {There is {count} of {total} item available}
-                            other {There is {count} of {total} items available}
-                        }
+        const resource = new ResourceString({
+            key: "plural.test",
+            sourceLocale: "en-US",
+            source: `{count, plural,
+                one {
+                    {total, plural,
+                        one {There is {count} of {total} item available}
+                        other {There is {count} of {total} items available}
                     }
-                    other {
-                        {total, plural,
-                            one {There are {count} of {total} item available}
-                            other {There are {count} of {total} items available}
-                        }
+                }
+                other {
+                    {total, plural,
+                        one {There are {count} of {total} item available}
+                        other {There are {count} of {total} items available}
                     }
-                }`,
-                targetLocale: "ru-RU",
-                target: `{count, plural,
-                    one {
-                        {total, plural,
-                            one {Есть {count} из {total} статьи}
-                            few {Есть {count} из {total} статей}
-                            other {Есть {count} из {total} статей}
-                        }
+                }
+            }`,
+            targetLocale: "ru-RU",
+            target: `{count, plural,
+                one {
+                    {total, plural,
+                        one {Есть {count} из {total} статьи}
+                        few {Есть {count} из {total} статей}
+                        other {Есть {count} из {total} статей}
                     }
-                    few {
-                        {total, plural,
-                            one {Есть {count} из {total} статьи}
-                            other {Есть {count} из {total} статей}
-                        }
+                }
+                few {
+                    {total, plural,
+                        one {Есть {count} из {total} статьи}
+                        other {Есть {count} из {total} статей}
                     }
-                    other {
-                        {total, plural,
-                            one {Есть {count} из {total} статьи}
-                            other {Есть {count} из {total} статей}
-                        }
+                }
+                other {
+                    {total, plural,
+                        one {Есть {count} из {total} статьи}
+                        other {Есть {count} из {total} статей}
                     }
-                }`,
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x/y"
+                }
+            }`,
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
         });
         const expected = [
             new Result({
@@ -526,86 +550,86 @@ export const testRules = {
                 description: "Missing plural categories in target string: few. Expecting these: one, few, other",
                 id: "plural.test",
                 highlight: 'Target: {count, plural,\n' +
-                    '                    one {\n' +
-                    '                        {total, plural,\n' +
-                    '                            one {Есть {count} из {total} статьи}\n' +
-                    '                            few {Есть {count} из {total} статей}\n' +
-                    '                            other {Есть {count} из {total} статей}\n' +
-                    '                        }\n' +
+                    '                one {\n' +
+                    '                    {total, plural,\n' +
+                    '                        one {Есть {count} из {total} статьи}\n' +
+                    '                        few {Есть {count} из {total} статей}\n' +
+                    '                        other {Есть {count} из {total} статей}\n' +
                     '                    }\n' +
-                    '                    few {\n' +
-                    '                        {total, plural,\n' +
-                    '                            one {Есть {count} из {total} статьи}\n' +
-                    '                            other {Есть {count} из {total} статей}\n' +
-                    '                        }\n' +
+                    '                }\n' +
+                    '                few {\n' +
+                    '                    {total, plural,\n' +
+                    '                        one {Есть {count} из {total} статьи}\n' +
+                    '                        other {Есть {count} из {total} статей}\n' +
                     '                    }\n' +
-                    '                    other {\n' +
-                    '                        {total, plural,\n' +
-                    '                            one {Есть {count} из {total} статьи}\n' +
-                    '                            other {Есть {count} из {total} статей}\n' +
-                    '                        }\n' +
+                    '                }\n' +
+                    '                other {\n' +
+                    '                    {total, plural,\n' +
+                    '                        one {Есть {count} из {total} статьи}\n' +
+                    '                        other {Есть {count} из {total} статей}\n' +
                     '                    }\n' +
-                    '                }<e0></e0>',
+                    '                }\n' +
+                    '            }<e0></e0>',
                 rule,
-                pathName: "x/y",
+                pathName: "a/b/c.xliff",
                 locale: "ru-RU",
                 source: `{count, plural,
-                    one {
-                        {total, plural,
-                            one {There is {count} of {total} item available}
-                            other {There is {count} of {total} items available}
-                        }
+                one {
+                    {total, plural,
+                        one {There is {count} of {total} item available}
+                        other {There is {count} of {total} items available}
                     }
-                    other {
-                        {total, plural,
-                            one {There are {count} of {total} item available}
-                            other {There are {count} of {total} items available}
-                        }
+                }
+                other {
+                    {total, plural,
+                        one {There are {count} of {total} item available}
+                        other {There are {count} of {total} items available}
                     }
-                }`
+                }
+            }`
             }),
             new Result({
                 severity: "error",
                 description: "Missing plural categories in target string: few. Expecting these: one, few, other",
                 id: "plural.test",
                 highlight: 'Target: {count, plural,\n' +
-                    '                    one {\n' +
-                    '                        {total, plural,\n' +
-                    '                            one {Есть {count} из {total} статьи}\n' +
-                    '                            few {Есть {count} из {total} статей}\n' +
-                    '                            other {Есть {count} из {total} статей}\n' +
-                    '                        }\n' +
+                    '                one {\n' +
+                    '                    {total, plural,\n' +
+                    '                        one {Есть {count} из {total} статьи}\n' +
+                    '                        few {Есть {count} из {total} статей}\n' +
+                    '                        other {Есть {count} из {total} статей}\n' +
                     '                    }\n' +
-                    '                    few {\n' +
-                    '                        {total, plural,\n' +
-                    '                            one {Есть {count} из {total} статьи}\n' +
-                    '                            other {Есть {count} из {total} статей}\n' +
-                    '                        }\n' +
+                    '                }\n' +
+                    '                few {\n' +
+                    '                    {total, plural,\n' +
+                    '                        one {Есть {count} из {total} статьи}\n' +
+                    '                        other {Есть {count} из {total} статей}\n' +
                     '                    }\n' +
-                    '                    other {\n' +
-                    '                        {total, plural,\n' +
-                    '                            one {Есть {count} из {total} статьи}\n' +
-                    '                            other {Есть {count} из {total} статей}\n' +
-                    '                        }\n' +
+                    '                }\n' +
+                    '                other {\n' +
+                    '                    {total, plural,\n' +
+                    '                        one {Есть {count} из {total} статьи}\n' +
+                    '                        other {Есть {count} из {total} статей}\n' +
                     '                    }\n' +
-                    '                }<e0></e0>',
+                    '                }\n' +
+                    '            }<e0></e0>',
                 rule,
-                pathName: "x/y",
+                pathName: "a/b/c.xliff",
                 locale: "ru-RU",
                 source: `{count, plural,
-                    one {
-                        {total, plural,
-                            one {There is {count} of {total} item available}
-                            other {There is {count} of {total} items available}
-                        }
+                one {
+                    {total, plural,
+                        one {There is {count} of {total} item available}
+                        other {There is {count} of {total} items available}
                     }
-                    other {
-                        {total, plural,
-                            one {There are {count} of {total} item available}
-                            other {There are {count} of {total} items available}
-                        }
+                }
+                other {
+                    {total, plural,
+                        one {There are {count} of {total} item available}
+                        other {There are {count} of {total} items available}
                     }
-                }`
+                }
+            }`
             }),
         ]
         test.deepEqual(actual, expected);
@@ -633,7 +657,7 @@ export const testRules = {
                 pathName: "a/b/c.xliff",
                 state: "translated"
             }),
-            file: "x/y"
+            file: "a/b/c.xliff"
         });
         test.ok(!actual);
 
@@ -660,7 +684,7 @@ export const testRules = {
                 pathName: "a/b/c.xliff",
                 state: "needs-review"
             }),
-            file: "x/y"
+            file: "a/b/c.xliff"
         });
         test.ok(!actual);
 
@@ -687,7 +711,7 @@ export const testRules = {
                 pathName: "a/b/c.xliff",
                 state: "new"
             }),
-            file: "x/y"
+            file: "a/b/c.xliff"
         });
         const expected = new Result({
             severity: "error",
@@ -695,7 +719,7 @@ export const testRules = {
             id: "plural.test",
             highlight: 'Resource found with disallowed state: <e0>new</e0>',
             rule,
-            pathName: "x/y",
+            pathName: "a/b/c.xliff",
             locale: "de-DE",
             source: '{count, plural, one {This is singular} other {This is plural}}'
         });
@@ -724,7 +748,7 @@ export const testRules = {
                 pathName: "a/b/c.xliff",
                 state: "new"
             }),
-            file: "x/y"
+            file: "a/b/c.xliff"
         });
         const expected = new Result({
             severity: "error",
@@ -732,7 +756,7 @@ export const testRules = {
             id: "plural.test",
             highlight: 'Resource found with disallowed state: <e0>new</e0>',
             rule,
-            pathName: "x/y",
+            pathName: "a/b/c.xliff",
             locale: "de-DE",
             source: '{count, plural, one {This is singular} other {This is plural}}'
         });
@@ -758,7 +782,7 @@ export const testRules = {
                 pathName: "a/b/c.xliff",
                 state: "translated"
             }),
-            file: "x/y"
+            file: "a/b/c.xliff"
         });
         test.ok(!actual);
 
@@ -782,7 +806,7 @@ export const testRules = {
                 pathName: "a/b/c.xliff",
                 state: "new"
             }),
-            file: "x/y"
+            file: "a/b/c.xliff"
         });
         const expected = new Result({
             severity: "error",
@@ -790,7 +814,7 @@ export const testRules = {
             id: "plural.test",
             highlight: 'Resource found with disallowed state: <e0>new</e0>',
             rule,
-            pathName: "x/y",
+            pathName: "a/b/c.xliff",
             locale: "de-DE",
             source: '{count, plural, one {This is singular} other {This is plural}}'
         });
@@ -818,7 +842,7 @@ export const testRules = {
                 target: "{count, plural, one {Dies ist einzigartig} other {Dies ist mehrerartig}}",
                 pathName: "a/b/c.xliff"
             }),
-            file: "x/y"
+            file: "a/b/c.xliff"
         });
         const expected = new Result({
             severity: "error",
@@ -826,7 +850,7 @@ export const testRules = {
             id: "plural.test",
             highlight: 'Resource found with no state.',
             rule,
-            pathName: "x/y",
+            pathName: "a/b/c.xliff",
             locale: "de-DE",
             source: '{count, plural, one {This is singular} other {This is plural}}'
         });
@@ -841,21 +865,23 @@ export const testRules = {
         const rule = new ResourceEdgeWhitespace();
         test.ok(rule);
 
+        const resource = new ResourceString({
+            key: "resource-edge-whitespace.both-edges-match",
+            sourceLocale: "en-US",
+            source: "Some source string. ",
+            targetLocale: "de-DE",
+            target: "Some target string. ",
+            pathName: "resource-edge-whitespace-test.xliff",
+            state: "translated",
+        });
         const subject = {
-            locale: "de-DE",
-            file: "x/y",
-            resource: new ResourceString({
-                key: "resource-edge-whitespace.both-edges-match",
-                sourceLocale: "en-US",
-                source: "Some source string. ",
-                targetLocale: "de-DE",
-                target: "Some target string. ",
-                pathName: "resource-edge-whitespace-test.xliff",
-                state: "translated",
-            }),
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
         };
 
-        const result = rule.match(subject);
+        const result = rule.matchString(subject);
         test.equal(result, undefined); // for a valid resource match result should not be produced
         test.done();
     },
@@ -866,27 +892,29 @@ export const testRules = {
         const rule = new ResourceEdgeWhitespace();
         test.ok(rule);
 
+        const resource = new ResourceString({
+            key: "resource-edge-whitespace.leading-space-missing",
+            sourceLocale: "en-US",
+            source: " some source string.",
+            targetLocale: "de-DE",
+            target: "some target string.",
+            pathName: "resource-edge-whitespace-test.xliff",
+            state: "translated",
+        });
         const subject = {
             // accidentally ommited space in front of target string
-            locale: "de-DE",
-            file: "x/y",
-            resource: new ResourceString({
-                key: "resource-edge-whitespace.leading-space-missing",
-                sourceLocale: "en-US",
-                source: " some source string.",
-                targetLocale: "de-DE",
-                target: "some target string.",
-                pathName: "resource-edge-whitespace-test.xliff",
-                state: "translated",
-            }),
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
         };
-        const result = rule.match(subject);
+        const result = rule.matchString(subject);
         test.deepEqual(
             result,
             new Result({
                 rule,
                 severity: "error",
-                pathName: "x/y",
+                pathName: "a/b/c.xliff",
                 locale: "de-DE",
                 source: " some source string.",
                 id: "resource-edge-whitespace.leading-space-missing",
@@ -903,27 +931,29 @@ export const testRules = {
         const rule = new ResourceEdgeWhitespace();
         test.ok(rule);
 
+        const resource = new ResourceString({
+            key: "resource-edge-whitespace.leading-space-extra",
+            sourceLocale: "en-US",
+            source: "Some source string.",
+            targetLocale: "de-DE",
+            target: " Some target string.",
+            pathName: "resource-edge-whitespace-test.xliff",
+            state: "translated",
+        });
         const subject = {
             // accidentally added space in front of target string
-            locale: "de-DE",
-            file: "x/y",
-            resource: new ResourceString({
-                key: "resource-edge-whitespace.leading-space-extra",
-                sourceLocale: "en-US",
-                source: "Some source string.",
-                targetLocale: "de-DE",
-                target: " Some target string.",
-                pathName: "resource-edge-whitespace-test.xliff",
-                state: "translated",
-            }),
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
         };
-        const result = rule.match(subject);
+        const result = rule.matchString(subject);
         test.deepEqual(
             result,
             new Result({
                 rule,
                 severity: "error",
-                pathName: "x/y",
+                pathName: "a/b/c.xliff",
                 locale: "de-DE",
                 source: "Some source string.",
                 id: "resource-edge-whitespace.leading-space-extra",
@@ -940,27 +970,29 @@ export const testRules = {
         const rule = new ResourceEdgeWhitespace();
         test.ok(rule);
 
+        const resource = new ResourceString({
+            key: "resource-edge-whitespace.trailing-space-missing",
+            sourceLocale: "en-US",
+            source: "Some source string ",
+            targetLocale: "de-DE",
+            target: "Some target string",
+            pathName: "resource-edge-whitespace-test.xliff",
+            state: "translated",
+        });
         const subject = {
             // accidentally ommited space in the end of target string
-            locale: "de-DE",
-            file: "x/y",
-            resource: new ResourceString({
-                key: "resource-edge-whitespace.trailing-space-missing",
-                sourceLocale: "en-US",
-                source: "Some source string ",
-                targetLocale: "de-DE",
-                target: "Some target string",
-                pathName: "resource-edge-whitespace-test.xliff",
-                state: "translated",
-            }),
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
         };
-        const result = rule.match(subject);
+        const result = rule.matchString(subject);
         test.deepEqual(
             result,
             new Result({
                 rule,
                 severity: "error",
-                pathName: "x/y",
+                pathName: "a/b/c.xliff",
                 locale: "de-DE",
                 source: "Some source string ",
                 id: "resource-edge-whitespace.trailing-space-missing",
@@ -977,27 +1009,29 @@ export const testRules = {
         const rule = new ResourceEdgeWhitespace();
         test.ok(rule);
 
+        const resource = new ResourceString({
+            key: "resource-edge-whitespace.trailing-space-extra",
+            sourceLocale: "en-US",
+            source: "Some source string.",
+            targetLocale: "de-DE",
+            target: "Some target string. ",
+            pathName: "resource-edge-whitespace-test.xliff",
+            state: "translated",
+        });
         const subject = {
             // accidentally added space in the end of target string
-            locale: "de-DE",
-            file: "x/y",
-            resource: new ResourceString({
-                key: "resource-edge-whitespace.trailing-space-extra",
-                sourceLocale: "en-US",
-                source: "Some source string.",
-                targetLocale: "de-DE",
-                target: "Some target string. ",
-                pathName: "resource-edge-whitespace-test.xliff",
-                state: "translated",
-            }),
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
         };
-        const result = rule.match(subject);
+        const result = rule.matchString(subject);
         test.deepEqual(
             result,
             new Result({
                 rule,
                 severity: "error",
-                pathName: "x/y",
+                pathName: "a/b/c.xliff",
                 locale: "de-DE",
                 source: "Some source string.",
                 id: "resource-edge-whitespace.trailing-space-extra",
@@ -1014,27 +1048,29 @@ export const testRules = {
         const rule = new ResourceEdgeWhitespace();
         test.ok(rule);
 
+        const resource = new ResourceString({
+            key: "resource-edge-whitespace.trailing-space-extra-more",
+            sourceLocale: "en-US",
+            source: "Some source string ",
+            targetLocale: "de-DE",
+            target: "Some target string  ",
+            pathName: "resource-edge-whitespace-test.xliff",
+            state: "translated",
+        });
         const subject = {
             // accidentally added space in the end of target string
-            locale: "de-DE",
-            file: "x/y",
-            resource: new ResourceString({
-                key: "resource-edge-whitespace.trailing-space-extra-more",
-                sourceLocale: "en-US",
-                source: "Some source string ",
-                targetLocale: "de-DE",
-                target: "Some target string  ",
-                pathName: "resource-edge-whitespace-test.xliff",
-                state: "translated",
-            }),
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
         };
-        const result = rule.match(subject);
+        const result = rule.matchString(subject);
         test.deepEqual(
             result,
             new Result({
                 rule,
                 severity: "error",
-                pathName: "x/y",
+                pathName: "a/b/c.xliff",
                 locale: "de-DE",
                 source: "Some source string ",
                 id: "resource-edge-whitespace.trailing-space-extra-more",
@@ -1051,26 +1087,28 @@ export const testRules = {
         const rule = new ResourceEdgeWhitespace();
         test.ok(rule);
 
+        const resource = new ResourceString({
+            key: "resource-edge-whitespace.both-spaces-missing",
+            sourceLocale: "en-US",
+            source: " some source string ",
+            targetLocale: "de-DE",
+            target: "some target string",
+            pathName: "resource-edge-whitespace-test.xliff",
+            state: "translated",
+        });
         const subject = {
             // accidentally ommited space in front and in the end of target string
-            locale: "de-DE",
-            file: "x/y",
-            resource: new ResourceString({
-                key: "resource-edge-whitespace.both-spaces-missing",
-                sourceLocale: "en-US",
-                source: " some source string ",
-                targetLocale: "de-DE",
-                target: "some target string",
-                pathName: "resource-edge-whitespace-test.xliff",
-                state: "translated",
-            }),
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
         };
-        const result = rule.match(subject);
+        const result = rule.matchString(subject);
         test.deepEqual(result, [
             new Result({
                 rule,
                 severity: "error",
-                pathName: "x/y",
+                pathName: "a/b/c.xliff",
                 locale: "de-DE",
                 source: " some source string ",
                 id: "resource-edge-whitespace.both-spaces-missing",
@@ -1080,7 +1118,7 @@ export const testRules = {
             new Result({
                 rule,
                 severity: "error",
-                pathName: "x/y",
+                pathName: "a/b/c.xliff",
                 locale: "de-DE",
                 source: " some source string ",
                 id: "resource-edge-whitespace.both-spaces-missing",
@@ -1097,21 +1135,23 @@ export const testRules = {
         const rule = new ResourceEdgeWhitespace();
         test.ok(rule);
 
+        const resource = new ResourceString({
+            key: "resource-edge-whitespace.spaces-only-match",
+            sourceLocale: "en-US",
+            source: " ",
+            targetLocale: "de-DE",
+            target: " ",
+            pathName: "resource-edge-whitespace-test.xliff",
+            state: "translated",
+        });
         const subject = {
             // all-whitespace string
-            locale: "de-DE",
-            file: "x/y",
-            resource: new ResourceString({
-                key: "resource-edge-whitespace.spaces-only-match",
-                sourceLocale: "en-US",
-                source: " ",
-                targetLocale: "de-DE",
-                target: " ",
-                pathName: "resource-edge-whitespace-test.xliff",
-                state: "translated",
-            }),
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
         };
-        const result = rule.match(subject);
+        const result = rule.matchString(subject);
         test.equal(result, undefined); // for a valid resource match result should not be produced
         test.done();
     },
@@ -1122,27 +1162,29 @@ export const testRules = {
         const rule = new ResourceEdgeWhitespace();
         test.ok(rule);
 
+        const resource = new ResourceString({
+            key: "resource-edge-whitespace.spaces-only-extra",
+            sourceLocale: "en-US",
+            source: " ",
+            targetLocale: "de-DE",
+            target: "  ",
+            pathName: "resource-edge-whitespace-test.xliff",
+            state: "translated",
+        });
         const subject = {
             // all-whitespace string
-            locale: "de-DE",
-            file: "x/y",
-            resource: new ResourceString({
-                key: "resource-edge-whitespace.spaces-only-extra",
-                sourceLocale: "en-US",
-                source: " ",
-                targetLocale: "de-DE",
-                target: "  ",
-                pathName: "resource-edge-whitespace-test.xliff",
-                state: "translated",
-            }),
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
         };
-        const result = rule.match(subject);
+        const result = rule.matchString(subject);
         test.deepEqual(
             result,
             new Result({
                 rule,
                 severity: "error",
-                pathName: "x/y",
+                pathName: "a/b/c.xliff",
                 locale: "de-DE",
                 source: " ",
                 id: "resource-edge-whitespace.spaces-only-extra",
@@ -1159,21 +1201,23 @@ export const testRules = {
         const rule = new ResourceEdgeWhitespace();
         test.ok(rule);
 
+        const resource = new ResourceString({
+            key: "resource-edge-whitespace.undefined-source",
+            sourceLocale: "en-US",
+            source: undefined,
+            targetLocale: "de-DE",
+            target: " ",
+            pathName: "resource-edge-whitespace-test.xliff",
+            state: "translated",
+        });
         const subject = {
             // missing source
-            locale: "de-DE",
-            file: "x/y",
-            resource: new ResourceString({
-                key: "resource-edge-whitespace.undefined-source",
-                sourceLocale: "en-US",
-                source: undefined,
-                targetLocale: "de-DE",
-                target: " ",
-                pathName: "resource-edge-whitespace-test.xliff",
-                state: "translated",
-            }),
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
         };
-        const result = rule.match(subject);
+        const result = rule.matchString(subject);
         test.equal(result, undefined); // this rule should not process a resource where source is not a string
         test.done();
     },
@@ -1184,21 +1228,23 @@ export const testRules = {
         const rule = new ResourceEdgeWhitespace();
         test.ok(rule);
 
+        const resource = new ResourceString({
+            key: "resource-edge-whitespace.undefined-target",
+            sourceLocale: "en-US",
+            source: " ",
+            targetLocale: "de-DE",
+            target: undefined,
+            pathName: "resource-edge-whitespace-test.xliff",
+            state: "translated",
+        });
         const subject = {
             // missing target
-            locale: "de-DE",
-            file: "x/y",
-            resource: new ResourceString({
-                key: "resource-edge-whitespace.undefined-target",
-                sourceLocale: "en-US",
-                source: " ",
-                targetLocale: "de-DE",
-                target: undefined,
-                pathName: "resource-edge-whitespace-test.xliff",
-                state: "translated",
-            }),
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
         };
-        const result = rule.match(subject);
+        const result = rule.matchString(subject);
         test.equal(result, undefined); // this rule should not process a resource where target is not a string
         test.done();
     },
@@ -1209,21 +1255,23 @@ export const testRules = {
         const rule = new ResourceCompleteness();
         test.ok(rule);
 
+        const resource = new ResourceString({
+            key: "resource-completeness-test.complete",
+            sourceLocale: "en-US",
+            source: "Some source string.",
+            targetLocale: "de-DE",
+            target: "Some target string.",
+            pathName: "completeness-test.xliff",
+            state: "translated",
+        });
         const subject = {
-            locale: "de-DE",
-            file: "x/y",
-            resource: new ResourceString({
-                key: "resource-completeness-test.complete",
-                sourceLocale: "en-US",
-                source: "Some source string.",
-                targetLocale: "de-DE",
-                target: "Some target string.",
-                pathName: "completeness-test.xliff",
-                state: "translated",
-            }),
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
         };
 
-        const result = rule.match(subject);
+        const result = rule.matchString(subject);
         test.equal(result, undefined); // for a valid resource match result should not be produced
         test.done();
     },
@@ -1234,27 +1282,29 @@ export const testRules = {
         const rule = new ResourceCompleteness();
         test.ok(rule);
 
+        const resource = new ResourceString({
+            key: "resource-completeness-test.extra-target",
+            sourceLocale: "en-US",
+            source: undefined,
+            targetLocale: "de-DE",
+            target: "Some target string.",
+            pathName: "completeness-test.xliff",
+            state: "translated",
+        });
         const subject = {
-            locale: "de-DE",
-            file: "x/y",
-            resource: new ResourceString({
-                key: "resource-completeness-test.extra-target",
-                sourceLocale: "en-US",
-                source: undefined,
-                targetLocale: "de-DE",
-                target: "Some target string.",
-                pathName: "completeness-test.xliff",
-                state: "translated",
-            }),
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
         };
 
-        const result = rule.match(subject);
+        const result = rule.matchString(subject);
         test.deepEqual(
             result,
             new Result({
                 rule,
                 severity: "warning",
-                pathName: "x/y",
+                pathName: "a/b/c.xliff",
                 locale: "de-DE",
                 source: undefined,
                 id: "resource-completeness-test.extra-target",
@@ -1271,27 +1321,29 @@ export const testRules = {
         const rule = new ResourceCompleteness();
         test.ok(rule);
 
+        const resource = new ResourceString({
+            key: "resource-completeness-test.target-missing",
+            sourceLocale: "en-US",
+            source: "Some source string.",
+            targetLocale: "de-DE",
+            target: undefined,
+            pathName: "completeness-test.xliff",
+            state: "translated",
+        });
         const subject = {
-            locale: "de-DE",
-            file: "x/y",
-            resource: new ResourceString({
-                key: "resource-completeness-test.target-missing",
-                sourceLocale: "en-US",
-                source: "Some source string.",
-                targetLocale: "de-DE",
-                target: undefined,
-                pathName: "completeness-test.xliff",
-                state: "translated",
-            }),
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
         };
 
-        const result = rule.match(subject);
+        const result = rule.matchString(subject);
         test.deepEqual(
             result,
             new Result({
                 rule,
                 severity: "error",
-                pathName: "x/y",
+                pathName: "a/b/c.xliff",
                 locale: "de-DE",
                 source: "Some source string.",
                 id: "resource-completeness-test.target-missing",
@@ -1308,21 +1360,23 @@ export const testRules = {
         const rule = new ResourceCompleteness();
         test.ok(rule);
 
+        const resource = new ResourceString({
+            key: "resource-completeness-test.target-missing-same-language",
+            sourceLocale: "en-US",
+            source: "Some source string.",
+            targetLocale: "en-GB",
+            target: undefined,
+            pathName: "completeness-test.xliff",
+            state: "translated",
+        });
         const subject = {
-            locale: "en-US",
-            file: "x/y",
-            resource: new ResourceString({
-                key: "resource-completeness-test.target-missing-same-language",
-                sourceLocale: "en-US",
-                source: "Some source string.",
-                targetLocale: "en-GB",
-                target: undefined,
-                pathName: "completeness-test.xliff",
-                state: "translated",
-            }),
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
         };
 
-        const result = rule.match(subject);
+        const result = rule.matchString(subject);
         // no error should be produced -
         // en-US and en-GB have same language so target value is optional in this case
         // (it can be ommited for those resources where target is equal to source)
@@ -1340,10 +1394,10 @@ export const testRules = {
         });
         test.ok(rule);
 
-        const subject = {
-            locale: "de-DE",
-            file: "x/y",
-            resource: new ResourceString({
+        const subject = new IntermediateRepresentation({
+            filePath: "a/b/c.xliff",
+            type: "resource",
+            ir: [new ResourceString({
                 key: "resource-dnt-test.dnt-missing",
                 sourceLocale: "en-US",
                 source: "Some source string with Some DNT term in it.",
@@ -1351,22 +1405,25 @@ export const testRules = {
                 target: "Some target string with an incorrecly translated DNT term in it.",
                 pathName: "dnt-test.xliff",
                 state: "translated",
-            }),
-        };
+            })]
+        });
 
-        const result = rule.match(subject);
+        const result = rule.match({
+            ir: subject,
+            file: "a/b/c.xliff"
+        });
         test.deepEqual(
             result,
-            [new Result({
+            new Result({
                 rule,
                 severity: "error",
-                pathName: "x/y",
+                pathName: "a/b/c.xliff",
                 locale: "de-DE",
                 source: "Some source string with Some DNT term in it.",
                 id: "resource-dnt-test.dnt-missing",
                 description: "A DNT term is missing in target string.",
                 highlight: `Missing term: <e0>Some DNT term</e0>`,
-            })]
+            })
         );
         test.done();
     },
@@ -1381,10 +1438,10 @@ export const testRules = {
         });
         test.ok(rule);
 
-        const subject = {
-            locale: "de-DE",
-            file: "x/y",
-            resource: new ResourceString({
+        const subject = new IntermediateRepresentation({
+            filePath: "a/b/c.xliff",
+            type: "resource",
+            ir: [new ResourceString({
                 key: "resource-dnt-test.dnt-terms-from-txt",
                 sourceLocale: "en-US",
                 source: "Some source string with Some DNT term in it.",
@@ -1392,22 +1449,25 @@ export const testRules = {
                 target: "Some target string with an incorrecly translated DNT term in it.",
                 pathName: "dnt-test.xliff",
                 state: "translated",
-            }),
-        };
+            })]
+        });
 
-        const result = rule.match(subject);
+        const result = rule.match({
+            ir: subject,
+            file: "a/b/c.xliff"
+        });
         test.deepEqual(
             result,
-            [new Result({
+            new Result({
                 rule,
                 severity: "error",
-                pathName: "x/y",
+                pathName: "a/b/c.xliff",
                 locale: "de-DE",
                 source: "Some source string with Some DNT term in it.",
                 id: "resource-dnt-test.dnt-terms-from-txt",
                 description: "A DNT term is missing in target string.",
                 highlight: `Missing term: <e0>Some DNT term</e0>`,
-            })]
+            })
         );
         test.done();
     },
@@ -1422,10 +1482,10 @@ export const testRules = {
         });
         test.ok(rule);
 
-        const subject = {
-            locale: "de-DE",
-            file: "x/y",
-            resource: new ResourceString({
+        const subject = new IntermediateRepresentation({
+            filePath: "a/b/c.xliff",
+            type: "resource",
+            ir: [new ResourceString({
                 key: "resource-dnt-test.dnt-terms-from-json",
                 sourceLocale: "en-US",
                 source: "Some source string with Some DNT term in it.",
@@ -1433,22 +1493,25 @@ export const testRules = {
                 target: "Some target string with an incorrecly translated DNT term in it.",
                 pathName: "dnt-test.xliff",
                 state: "translated",
-            }),
-        };
+            })]
+        });
 
-        const result = rule.match(subject);
+        const result = rule.match({
+            ir: subject,
+            file: "a/b/c.xliff"
+        });
         test.deepEqual(
             result,
-            [new Result({
+            new Result({
                 rule,
                 severity: "error",
-                pathName: "x/y",
+                pathName: "a/b/c.xliff",
                 locale: "de-DE",
                 source: "Some source string with Some DNT term in it.",
                 id: "resource-dnt-test.dnt-terms-from-json",
                 description: "A DNT term is missing in target string.",
                 highlight: `Missing term: <e0>Some DNT term</e0>`,
-            })]
+            })
         );
         test.done();
     },
@@ -1465,10 +1528,10 @@ export const testRules = {
         });
         test.ok(rule);
 
-        const subject = {
-            locale: "de-DE",
-            file: "x/y",
-            resource: new ResourceString({
+        const subject = new IntermediateRepresentation({
+            filePath: "a/b/c.xliff",
+            type: "resource",
+            ir: [new ResourceString({
                 key: "resource-dnt-test.dnt-missing-multiple",
                 sourceLocale: "en-US",
                 source: "Some source string with Some DNT term and Another DNT term in it.",
@@ -1476,17 +1539,20 @@ export const testRules = {
                 target: "Some target string with an incorrecly translated DNT term and another incorrecly translated DNT term in it.",
                 pathName: "dnt-test.xliff",
                 state: "translated",
-            }),
-        };
+            })]
+        });
 
-        const result = rule.match(subject);
+        const result = rule.match({
+            ir: subject,
+            file: "a/b/c.xliff"
+        });
         test.deepEqual(
             result,
             [
                 new Result({
                     rule,
                     severity: "error",
-                    pathName: "x/y",
+                    pathName: "a/b/c.xliff",
                     locale: "de-DE",
                     source: "Some source string with Some DNT term and Another DNT term in it.",
                     id: "resource-dnt-test.dnt-missing-multiple",
@@ -1496,7 +1562,7 @@ export const testRules = {
                 new Result({
                     rule,
                     severity: "error",
-                    pathName: "x/y",
+                    pathName: "a/b/c.xliff",
                     locale: "de-DE",
                     source: "Some source string with Some DNT term and Another DNT term in it.",
                     id: "resource-dnt-test.dnt-missing-multiple",
@@ -1518,10 +1584,10 @@ export const testRules = {
         });
         test.ok(rule);
 
-        const subject = {
-            locale: "de-DE",
-            file: "x/y",
-            resource: new ResourceArray({
+        const subject = new IntermediateRepresentation({
+            filePath: "a/b/c.xliff",
+            type: "resource",
+            ir: [new ResourceArray({
                 key: "resource-dnt-test.dnt-missing-resource-array",
                 sourceLocale: "en-US",
                 source: ["not a DNT term item", "Some DNT term item"],
@@ -1529,22 +1595,25 @@ export const testRules = {
                 target: ["translated term item", "incorrecly translated DNT term item"],
                 pathName: "dnt-test.xliff",
                 state: "translated",
-            }),
-        };
+            })]
+        });
 
-        const result = rule.match(subject);
+        const result = rule.match({
+            ir: subject,
+            file: "a/b/c.xliff"
+        });
         test.deepEqual(
             result,
-            [new Result({
+            new Result({
                 rule,
                 severity: "error",
-                pathName: "x/y",
+                pathName: "a/b/c.xliff",
                 locale: "de-DE",
                 source: "Some DNT term item",
                 id: "resource-dnt-test.dnt-missing-resource-array",
                 description: "A DNT term is missing in target string.",
                 highlight: `Missing term: <e0>Some DNT term</e0>`,
-            })]
+            })
         );
         test.done();
     },
@@ -1560,15 +1629,15 @@ export const testRules = {
         });
         test.ok(rule);
 
-        const subject = {
-            locale: "de-DE",
-            file: "x/y",
-            resource: new ResourcePlural({
+        const subject = new IntermediateRepresentation({
+            filePath: "a/b/c.xliff",
+            type: "resource",
+            ir: [new ResourcePlural({
                 key: "resource-dnt-test.dnt-missing-resource-plural-all-categories",
                 sourceLocale: "en-US",
                 source: {
                     "one": "This is Some DNT term singular",
-                    "many": "This is Some DNT term many"
+                    "other": "This is Some DNT term many"
                 },
                 targetLocale: "de-DE",
                 target: {
@@ -1578,15 +1647,18 @@ export const testRules = {
                 },
                 pathName: "dnt-test.xliff",
                 state: "translated",
-            }),
-        };
+            })]
+        });
 
-        const result = rule.match(subject);
+        const result = rule.match({
+            ir: subject,
+            file: "a/b/c.xliff"
+        });
         test.deepEqual(result, [
             new Result({
                 rule,
                 severity: "error",
-                pathName: "x/y",
+                pathName: "a/b/c.xliff",
                 locale: "de-DE",
                 source: "This is Some DNT term singular",
                 id: "resource-dnt-test.dnt-missing-resource-plural-all-categories",
@@ -1596,9 +1668,10 @@ export const testRules = {
             new Result({
                 rule,
                 severity: "error",
-                pathName: "x/y",
+                pathName: "a/b/c.xliff",
                 locale: "de-DE",
-                source: undefined, // no category `two` defined in source
+                // no category `two` defined in source, so use "other"
+                source: "This is Some DNT term many",
                 id: "resource-dnt-test.dnt-missing-resource-plural-all-categories",
                 description: "A DNT term is missing in target string.",
                 highlight: `Missing term: <e0>Some DNT term</e0>`,
@@ -1618,10 +1691,10 @@ export const testRules = {
         });
         test.ok(rule);
 
-        const subject = {
-            locale: "de-DE",
-            file: "x/y",
-            resource: new ResourcePlural({
+        const subject = new IntermediateRepresentation({
+            filePath: "a/b/c.xliff",
+            type: "resource",
+            ir: [new ResourcePlural({
                 key: "resource-dnt-test.dnt-missing-resource-plural-some-categories",
                 sourceLocale: "en-US",
                 source: {
@@ -1636,22 +1709,23 @@ export const testRules = {
                 },
                 pathName: "dnt-test.xliff",
                 state: "translated",
-            }),
-        };
+            })]
+        });
 
-        const result = rule.match(subject);
-        test.deepEqual(result, [
-            new Result({
-                rule,
-                severity: "error",
-                pathName: "x/y",
-                locale: "de-DE",
-                source: "This is Some DNT term singular",
-                id: "resource-dnt-test.dnt-missing-resource-plural-some-categories",
-                description: "A DNT term is missing in target string.",
-                highlight: `Missing term: <e0>Some DNT term</e0>`,
-            })
-        ]);
+        const result = rule.match({
+            ir: subject,
+            file: "a/b/c.xliff"
+        });
+        test.deepEqual(result, new Result({
+            rule,
+            severity: "error",
+            pathName: "a/b/c.xliff",
+            locale: "de-DE",
+            source: "This is Some DNT term singular",
+            id: "resource-dnt-test.dnt-missing-resource-plural-some-categories",
+            description: "A DNT term is missing in target string.",
+            highlight: `Missing term: <e0>Some DNT term</e0>`,
+        }));
         test.done();
     },
 
@@ -1665,10 +1739,10 @@ export const testRules = {
         });
         test.ok(rule);
 
-        const subject = {
-            locale: "de-DE",
-            file: "x/y",
-            resource: new ResourceString({
+        const subject = new IntermediateRepresentation({
+            filePath: "a/b/c.xliff",
+            type: "resource",
+            ir: [new ResourceString({
                 key: "resource-dnt-test.dnt-ok",
                 sourceLocale: "en-US",
                 source: "Some source string with Some DNT term in it.",
@@ -1676,11 +1750,14 @@ export const testRules = {
                 target: "Some target string with Some DNT term in it.",
                 pathName: "dnt-test.xliff",
                 state: "translated",
-            }),
-        };
+            })]
+        });
 
-        const result = rule.match(subject);
-        test.deepEqual(result, []);
+        const result = rule.match({
+            ir: subject,
+            file: "a/b/c.xliff"
+        });
+        test.ok(!result);
         test.done();
     },
 
@@ -1694,10 +1771,10 @@ export const testRules = {
         });
         test.ok(rule);
 
-        const subject = {
-            locale: "de-DE",
-            file: "x/y",
-            resource: new ResourceArray({
+        const subject = new IntermediateRepresentation({
+            filePath: "a/b/c.xliff",
+            type: "resource",
+            ir: [new ResourceArray({
                 key: "resource-dnt-test.dnt-ok-resource-array",
                 sourceLocale: "en-US",
                 source: ["not a DNT term item", "Some DNT term item"],
@@ -1705,11 +1782,14 @@ export const testRules = {
                 target: ["translated term item", "correctly translated Some DNT term item"],
                 pathName: "dnt-test.xliff",
                 state: "translated",
-            }),
-        };
+            })]
+        });
 
-        const result = rule.match(subject);
-        test.deepEqual(result, []);
+        const result = rule.match({
+            ir: subject,
+            file: "a/b/c.xliff"
+        });
+        test.ok(!result);
         test.done();
     },
 
@@ -1723,10 +1803,10 @@ export const testRules = {
         });
         test.ok(rule);
 
-        const subject = {
-            locale: "de-DE",
-            file: "x/y",
-            resource: new ResourcePlural({
+        const subject = new IntermediateRepresentation({
+            filePath: "a/b/c.xliff",
+            type: "resource",
+            ir: [new ResourcePlural({
                 key: "resource-dnt-test.dnt-ok-resource-plural-all-categories",
                 sourceLocale: "en-US",
                 source: {
@@ -1741,11 +1821,14 @@ export const testRules = {
                 },
                 pathName: "dnt-test.xliff",
                 state: "translated",
-            }),
-        };
+            })]
+        });
 
-        const result = rule.match(subject);
-        test.deepEqual(result, []);
+        const result = rule.match({
+            ir: subject,
+            file: "a/b/c.xliff"
+        });
+        test.ok(!result);
         test.done();
     },
 
@@ -1759,10 +1842,10 @@ export const testRules = {
         });
         test.ok(rule);
 
-        const subject = {
-            locale: "de-DE",
-            file: "x/y",
-            resource: new ResourcePlural({
+        const subject = new IntermediateRepresentation({
+            filePath: "a/b/c.xliff",
+            type: "resource",
+            ir: [new ResourcePlural({
                 key: "resource-dnt-test.dnt-ok-resource-plural-some-categories",
                 sourceLocale: "en-US",
                 source: {
@@ -1777,11 +1860,14 @@ export const testRules = {
                 },
                 pathName: "dnt-test.xliff",
                 state: "translated",
-            }),
-        };
+            })]
+        });
 
-        const result = rule.match(subject);
-        test.deepEqual(result, []);
+        const result = rule.match({
+            ir: subject,
+            file: "a/b/c.xliff"
+        });
+        test.ok(!result);
         test.done();
     },
     

--- a/test/testRules.js
+++ b/test/testRules.js
@@ -148,6 +148,7 @@ export const testRules = {
             source: '{count, plural, one {This is singular} other {This is plural}}',
             highlight: 'Target: {count, plural, one {{Dies <e0>ist einzigartig} other {Dies ist mehrerartig}}</e0>',
             rule,
+            locale: "de-DE",
             pathName: "x/y"
         });
         test.deepEqual(actual, expected);
@@ -180,6 +181,7 @@ export const testRules = {
             source: '{count, plural, one {This is singular} other {This is plural}}',
             highlight: 'Target: {count, plural, one {Dies ist einzigartig} other {Dies ist mehrerartig}<e0></e0>',
             rule,
+            locale: "de-DE",
             pathName: "x/y"
         });
         test.deepEqual(actual, expected);
@@ -212,6 +214,7 @@ export const testRules = {
             source: '{count, plural, one {This is singular} other {This is plural}}',
             highlight: 'Target: {count, plural, eins {Dies ist einzigartig} andere {Dies ist mehrerartig}<e0>}</e0>',
             rule,
+            locale: "de-DE",
             pathName: "x/y"
         });
         test.deepEqual(actual, expected);
@@ -231,7 +234,7 @@ export const testRules = {
                 key: "plural.test",
                 sourceLocale: "en-US",
                 source: '{count, plural, one {This is singular} other {This is plural}}',
-                targetLocale: "de-DE",
+                targetLocale: "ru-RU",
                 target: "{count, plural, one {Это единственное число} other {это множественное число}}",
                 pathName: "a/b/c.xliff"
             }),
@@ -244,6 +247,7 @@ export const testRules = {
             source: '{count, plural, one {This is singular} other {This is plural}}',
             highlight: 'Target: {count, plural, one {Это единственное число} other {это множественное число}}<e0></e0>',
             rule,
+            locale: "ru-RU",
             pathName: "x/y"
         });
         test.deepEqual(actual, expected);
@@ -263,7 +267,7 @@ export const testRules = {
                 key: "plural.test",
                 sourceLocale: "en-US",
                 source: '{count, plural, other {This is plural}}',
-                targetLocale: "de-DE",
+                targetLocale: "ru-RU",
                 target: "{count, plural, one {Это единственное число} few {это множественное число} other {это множественное число}}",
                 pathName: "a/b/c.xliff"
             }),
@@ -300,6 +304,7 @@ export const testRules = {
             highlight: 'Target: {count, plural, one {Dies ist einzigartig} few {This is few} other {Dies ist mehrerartig}}<e0></e0>',
             rule,
             pathName: "x/y",
+            locale: "de-DE",
             source: '{count, plural, one {This is singular} other {This is plural}}'
         });
         test.deepEqual(actual, expected);
@@ -355,6 +360,7 @@ export const testRules = {
             highlight: 'Target: {count, plural, one {Dies ist einzigartig} other {Dies ist mehrerartig}}<e0></e0>',
             rule,
             pathName: "x/y",
+            locale: "de-DE",
             source: '{count, plural, =1 {This is one} one {This is singular} other {This is plural}}'
         });
         test.deepEqual(actual, expected);
@@ -442,6 +448,7 @@ export const testRules = {
                 '                }<e0></e0>',
             rule,
             pathName: "x/y",
+            locale: "ru-RU",
             source: `{count, plural,
                     one {
                         {total, plural,
@@ -541,6 +548,7 @@ export const testRules = {
                     '                }<e0></e0>',
                 rule,
                 pathName: "x/y",
+                locale: "ru-RU",
                 source: `{count, plural,
                     one {
                         {total, plural,
@@ -583,6 +591,7 @@ export const testRules = {
                     '                }<e0></e0>',
                 rule,
                 pathName: "x/y",
+                locale: "ru-RU",
                 source: `{count, plural,
                     one {
                         {total, plural,


### PR DESCRIPTION
- Added 2 new classes:
    - DeclarativeResourceRule -> ResourceRule -> Rule
    - ResourceRule implements match() where it handles iterating over the items in a resource array or the categories in a plural resource, calling matchString() on each of them
        - this can be used for declarative or programmatic resource rules
    - DeclarativeResourceRule implements matchString() and handles running a set of regular expressions on each string by calling checkString()
    - The following all now inherit from ResourceRule and implement the matchString() method:
        - ResourceEdgeWhitespace
        - ResourceICUPlurals
        - ResoruceICUPluralTranslation
        - ResourceNoTranslation
    - The following all now inherit from DeclarativeResourceRule and implement the checkString() method:
        - ResourceMatcher
        - ResourceSourceChecker
        - ResourceTargetChecker 