### PR TITLE
Add rule to check half-width kana characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -597,6 +597,7 @@ limitations under the License.
 - added rule to check if resources have both source and target defined
 - fixed bug where resources of type array or plural were not getting
   processed properly in the declarative rules
+- added rule to warn against half-width kana characters
 
 ### v1.5.0
 

--- a/docs/resource-no-halfwidth-kana-characters.md
+++ b/docs/resource-no-halfwidth-kana-characters.md
@@ -1,0 +1,8 @@
+# resource-no-halfwidth-kana-characters
+
+Ensure that translations do not contain [half-width (single byte) kana](https://en.wikipedia.org/wiki/Half-width_kana) characters. Use the equivalent full-width kana (double-byte) characters. 
+
+Examples:
+
+Good translation: "コミュニケーション"
+Bad translation: "ｺﾐｭﾆｹｰｼｮﾝ"

--- a/src/PluginManager.js
+++ b/src/PluginManager.js
@@ -103,7 +103,8 @@ export const builtInRulesets = {
         "resource-named-params": true,
         "resource-no-fullwidth-latin": true,
         "resource-no-fullwidth-digits": true,
-        "resource-no-fullwidth-punctuation-subset": true
+        "resource-no-fullwidth-punctuation-subset": true,
+        "resource-no-halfwidth-kana-characters": true,
     }
 };
 

--- a/src/PluginManager.js
+++ b/src/PluginManager.js
@@ -80,8 +80,8 @@ export const regexRules = [
         type: "resource-target",
         name: "resource-no-halfwidth-kana-characters",
         description: "Ensure that the target does not contain half-width kana characters.",
-        note: "The half-width kana characters '{matchString}' are not allowed in the target string. Use full-width characters.",
-        regexps: [ "([ｧ-ﾝﾞﾟ])" ],
+        note: "The half-width kana characters are not allowed in the target string. Use full-width characters.",
+        regexps: [ "[ｧ-ﾝﾞﾟ]+" ],
         link: "https://github.com/ilib-js/i18nlint/blob/main/docs/resource-no-halfwidth-kana-characters.md",
         severity: "warning",
     }

--- a/src/PluginManager.js
+++ b/src/PluginManager.js
@@ -75,6 +75,15 @@ export const regexRules = [
         note: "The full-width characters '{matchString}' are not allowed in the target string. Use ASCII symbols instead.",
         regexps: [ "[\\uFF01|\\uFF05|\\uFF1F]+" ],
         link: "https://github.com/ilib-js/i18nlint/blob/main/docs/resource-no-fullwidth-punctuation-subset.md"
+    },
+    {
+        type: "resource-target",
+        name: "resource-no-halfwidth-kana-characters",
+        description: "Ensure that the target does not contain half-width kana characters.",
+        note: "The half-width kana characters '{matchString}' are not allowed in the target string. Use full-width characters.",
+        regexps: [ "([ｧ-ﾝﾞﾟ])" ],
+        link: "https://github.com/ilib-js/i18nlint/blob/main/docs/resource-no-halfwidth-kana-characters.md",
+        severity: "warning",
     }
 ];
 

--- a/test/testResourceTargetChecker.js
+++ b/test/testResourceTargetChecker.js
@@ -460,46 +460,31 @@ export const testResourceTargetChecker = {
         );
         test.ok(rule);
 
-        const actual = rule.match({
+        const subject = {
             locale: "ja-JP",
             resource: new ResourceString({
                 key: "matcher.test",
                 sourceLocale: "en-US",
-                source: 'Communication',
+                source: "Communication",
                 targetLocale: "ja-JP",
                 target: "ｺﾐｭﾆｹｰｼｮﾝ",
-                pathName: "a/b/c.xliff"
+                pathName: "a/b/c.xliff",
             }),
-            file: "x/y"
-        });
-        test.ok(actual);
+            file: "x/y",
+        };
 
-        test.done();
-    },
-
-    testResourceNoHalfWidthKanaSuccess: function(test) {
-        test.expect(2);
-
-        const rule = new ResourceTargetChecker(
-            regexRules.find((r) => r.name === "resource-no-halfwidth-kana-characters")
-        );
-        test.ok(rule);
-
-        const actual = rule.match({
+        const result = rule.match(subject);
+        test.deepEqual(result, [new Result({
+            rule,
+            severity: "warning",
             locale: "ja-JP",
-            resource: new ResourceString({
-                key: "matcher.test",
-                sourceLocale: "en-US",
-                source: 'Communication',
-                targetLocale: "ja-JP",
-                target: "コミュニケーション",
-                pathName: "a/b/c.xliff"
-            }),
-            file: "x/y"
-        });
-        test.ok(!actual);
+            pathName: "x/y",
+            source: "Communication",
+            id: "matcher.test",
+            description: "The half-width kana characters are not allowed in the target string. Use full-width characters.",
+            highlight: "Target: <e0>ｺﾐｭﾆｹｰｼｮﾝ</e0>",
+        })]);
 
         test.done();
     },
 };
-

--- a/test/testResourceTargetChecker.js
+++ b/test/testResourceTargetChecker.js
@@ -450,6 +450,56 @@ export const testResourceTargetChecker = {
         test.equal(actual[2].highlight, "Target: 本当？ はい！ 100<e0>％</e0>");
 
         test.done();
-    }
+    },
+
+    testResourceNoHalfWidthKana: function(test) {
+        test.expect(2);
+
+        const rule = new ResourceTargetChecker(
+            regexRules.find((r) => r.name === "resource-no-halfwidth-kana-characters")
+        );
+        test.ok(rule);
+
+        const actual = rule.match({
+            locale: "ja-JP",
+            resource: new ResourceString({
+                key: "matcher.test",
+                sourceLocale: "en-US",
+                source: 'Communication',
+                targetLocale: "ja-JP",
+                target: "ｺﾐｭﾆｹｰｼｮﾝ",
+                pathName: "a/b/c.xliff"
+            }),
+            file: "x/y"
+        });
+        test.ok(actual);
+
+        test.done();
+    },
+
+    testResourceNoHalfWidthKanaSuccess: function(test) {
+        test.expect(2);
+
+        const rule = new ResourceTargetChecker(
+            regexRules.find((r) => r.name === "resource-no-halfwidth-kana-characters")
+        );
+        test.ok(rule);
+
+        const actual = rule.match({
+            locale: "ja-JP",
+            resource: new ResourceString({
+                key: "matcher.test",
+                sourceLocale: "en-US",
+                source: 'Communication',
+                targetLocale: "ja-JP",
+                target: "コミュニケーション",
+                pathName: "a/b/c.xliff"
+            }),
+            file: "x/y"
+        });
+        test.ok(!actual);
+
+        test.done();
+    },
 };
 


### PR DESCRIPTION
- New rule `resource-no-halfwidth-kana-characters` has been added.
- If target contains half-width kana character warning is returned. 
- Unit tests have been added. 