### PR TITLE
Fix plural checker when there are added or subtracted categories

### DIFF
--- a/src/rules/ResourceICUPluralTranslation.js
+++ b/src/rules/ResourceICUPluralTranslation.js
@@ -139,10 +139,12 @@ class ResourceICUPluralTranslation extends Rule {
                 // missing target plurals are for a different rule, so don't report it here
                 return;
             }
-            return Object.keys(sourcePlural.options).map(category => {
-                if (!targetPlural.options[category]) return; // nothing to check!
+            return Object.keys(targetPlural.options).map(category => {
+                const sourceCategory = sourcePlural.options[category] ? category : "other";
+                const sourcePluralCat = sourcePlural.options[sourceCategory];
+                if (!sourcePluralCat) return; // nothing to check!
 
-                const sourceStr = this.reconstruct(sourcePlural.options[category].value).replace(/\s+/g, " ").trim();
+                const sourceStr = this.reconstruct(sourcePluralCat.value).replace(/\s+/g, " ").trim();
                 const targetStr = this.reconstruct(targetPlural.options[category].value).replace(/\s+/g, " ").trim();
                 let result = [];
 
@@ -153,7 +155,7 @@ class ResourceICUPluralTranslation extends Rule {
                         description: `Translation of the category \'${category}\' is the same as the source.`,
                         rule: this,
                         id: resource.getKey(),
-                        source: `${category} {${sourceStr}}`,
+                        source: `${sourceCategory} {${sourceStr}}`,
                         highlight: `Target: <e0>${category} {${targetStr}}</e0>`,
                         pathName: file,
                         locale: resource.getTargetLocale()
@@ -165,7 +167,7 @@ class ResourceICUPluralTranslation extends Rule {
                 }
 
                 // now the plurals may have plurals nested in them, so recursively check them too
-                return result.concat(this.traverse(resource, file, sourcePlural.options[category].value, targetPlural.options[category].value));
+                return result.concat(this.traverse(resource, file, sourcePluralCat.value, targetPlural.options[category].value));
              }).flat();
         }).flat();
 

--- a/test/testResourceICUPluralTranslation.js
+++ b/test/testResourceICUPluralTranslation.js
@@ -459,5 +459,145 @@ export const testResourceICUPluralTranslation = {
 
         test.done();
     },
+
+    testResourceICUPluralTranslationsAddCategoryTranslated: function(test) {
+        test.expect(2);
+
+        const rule = new ResourceICUPluralTranslation();
+        test.ok(rule);
+
+        const actual = rule.match({
+            locale: "ru-RU",
+            resource: new ResourceString({
+                key: "plural.test",
+                sourceLocale: "en-US",
+                source: 'There {count, plural, one {is # file} other {are # files}} in the folder.',
+                targetLocale: "ru-RU",
+                target: 'There {count, plural, one {is # file (Russian)} few {are # files (Russian)} other {are # files (Russian)}} in the folder.',
+                pathName: "a/b/c.xliff"
+            }),
+            file: "x/y"
+        });
+        test.ok(!actual);
+
+        test.done();
+    },
+
+    testResourceICUPluralTranslationsAddCategoryNotTranslated: function(test) {
+        test.expect(5);
+
+        const rule = new ResourceICUPluralTranslation();
+        test.ok(rule);
+
+        const actual = rule.match({
+            locale: "ru-RU",
+            resource: new ResourceString({
+                key: "plural.test",
+                sourceLocale: "en-US",
+                source: 'There {count, plural, one {is # file} other {are # files}} in the folder.',
+                targetLocale: "ru-RU",
+                target: 'There {count, plural, one {is # file} few {are # files} other {are # files}} in the folder.',
+                pathName: "a/b/c.xliff"
+            }),
+            file: "x/y"
+        });
+        test.ok(actual);
+        test.ok(Array.isArray(actual));
+        test.equal(actual.length, 3);
+
+        const expected = [
+            new Result({
+                severity: "warning",
+                description: "Translation of the category 'one' is the same as the source.",
+                id: "plural.test",
+                highlight: 'Target: <e0>one {is # file}</e0>',
+                rule,
+                pathName: "x/y",
+                locale: "ru-RU",
+                source: 'one {is # file}'
+            }),
+            new Result({
+                severity: "warning",
+                description: "Translation of the category 'few' is the same as the source.",
+                id: "plural.test",
+                highlight: 'Target: <e0>few {are # files}</e0>',
+                rule,
+                pathName: "x/y",
+                locale: "ru-RU",
+                source: 'other {are # files}'
+            }),
+            new Result({
+                severity: "warning",
+                description: "Translation of the category 'other' is the same as the source.",
+                id: "plural.test",
+                highlight: 'Target: <e0>other {are # files}</e0>',
+                rule,
+                pathName: "x/y",
+                locale: "ru-RU",
+                source: 'other {are # files}'
+            }),
+        ];
+        test.deepEqual(actual, expected);
+
+        test.done();
+    },
+
+    testResourceICUPluralTranslationsSubtractCategoryTranslated: function(test) {
+        test.expect(2);
+
+        const rule = new ResourceICUPluralTranslation();
+        test.ok(rule);
+
+        const actual = rule.match({
+            locale: "ja-JP",
+            resource: new ResourceString({
+                key: "plural.test",
+                sourceLocale: "en-US",
+                source: 'There {count, plural, one {is # file} other {are # files}} in the folder.',
+                targetLocale: "ja-JP",
+                target: 'There {count, plural, other {are # files (Japanese)}} in the folder.',
+                pathName: "a/b/c.xliff"
+            }),
+            file: "x/y"
+        });
+        test.ok(!actual);
+
+        test.done();
+    },
+
+    testResourceICUPluralTranslationsSubtractCategoryNotTranslated: function(test) {
+        test.expect(3);
+
+        const rule = new ResourceICUPluralTranslation();
+        test.ok(rule);
+
+        const actual = rule.match({
+            locale: "ja-JP",
+            resource: new ResourceString({
+                key: "plural.test",
+                sourceLocale: "en-US",
+                source: 'There {count, plural, one {is # file} other {are # files}} in the folder.',
+                targetLocale: "ja-JP",
+                target: 'There {count, plural, other {are # files}} in the folder.',
+                pathName: "a/b/c.xliff"
+            }),
+            file: "x/y"
+        });
+        test.ok(actual);
+
+        const expected = new Result({
+            severity: "warning",
+            description: "Translation of the category 'other' is the same as the source.",
+            id: "plural.test",
+            highlight: 'Target: <e0>other {are # files}</e0>',
+            rule,
+            pathName: "x/y",
+            locale: "ja-JP",
+            source: 'other {are # files}'
+        });
+        test.deepEqual(actual, expected);
+
+        test.done();
+    },
 };
 


### PR DESCRIPTION
- should check any added categories in the plural to see if they are the same as the "other" in English
- also make sure when there are subtracted categories in Asian languages, it does not crash