### PR TITLE
Fixed problem with checking transunit with no state

### DIFF
--- a/README.md
+++ b/README.md
@@ -717,6 +717,11 @@ limitations under the License.
 
 ## Release Notes
 
+### v1.6.1
+
+- Having no state attribute on the target tag of a translation unit would
+  cause an exception. Now it properly gives an error that no state was found.
+
 ### v1.6.0
 
 - added the ability to scan source code files and apply rules

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-lint",
-    "version": "1.6.0",
+    "version": "1.6.1",
     "module": "./src/index.js",
     "type": "module",
     "bin": "./src/index.js",

--- a/src/rules/ResourceStateChecker.js
+++ b/src/rules/ResourceStateChecker.js
@@ -73,7 +73,7 @@ class ResourceStateChecker extends Rule {
      */
     match(options) {
         const { locale, resource, file } = options || {};
-        const state = resource.getState().toLowerCase();
+        const state = resource.getState()?.toLowerCase();
 
         if (state && this.states.indexOf(state) > -1) {
             // recognized state, so return no results
@@ -86,15 +86,16 @@ class ResourceStateChecker extends Rule {
             id: resource.getKey(),
             rule: this,
             pathName: file,
-            highlight: `Resource found with disallowed state: <e0>${state}</e0>`,
+            highlight: state ? `Resource found with disallowed state: <e0>${state}</e0>` : "Resource found with no state.",
             description: (this.states.length > 1) ?
                 `Resources must have one of the following states: ${this.states.join(", ")}` :
                 `Resources must have the following state: ${this.states[0]}`,
             locale,
             source: resource.getSource()
         };
-        if (typeof(options.lineNumber) !== 'undefined') {
-            value.lineNumber = options.lineNumber;
+        if (typeof(resource.lineNumber) !== 'undefined') {
+            value.lineNumber = resource.lineNumber;
+            value.charNumber = resource.charNumber;
         }
         return new Result(value);
     }

--- a/test/testRules.js
+++ b/test/testRules.js
@@ -790,6 +790,42 @@ export const testRules = {
         test.done();
     },
 
+    testResourceStateCheckerNoState: function(test) {
+        test.expect(2);
+
+        const rule = new ResourceStateChecker({
+            // all resources should have this state:
+            param: [ "translated" ]
+        });
+        test.ok(rule);
+
+        const actual = rule.match({
+            locale: "de-DE",
+            resource: new ResourceString({
+                key: "plural.test",
+                sourceLocale: "en-US",
+                source: '{count, plural, one {This is singular} other {This is plural}}',
+                targetLocale: "de-DE",
+                target: "{count, plural, one {Dies ist einzigartig} other {Dies ist mehrerartig}}",
+                pathName: "a/b/c.xliff"
+            }),
+            file: "x/y"
+        });
+        const expected = new Result({
+            severity: "error",
+            description: "Resources must have the following state: translated",
+            id: "plural.test",
+            highlight: 'Resource found with no state.',
+            rule,
+            pathName: "x/y",
+            locale: "de-DE",
+            source: '{count, plural, one {This is singular} other {This is plural}}'
+        });
+        test.deepEqual(actual, expected);
+
+        test.done();
+    },
+
     testResourceEdgeWhitespaceEdgesMatch: function(test) {
         test.expect(2);
 


### PR DESCRIPTION
- Having no state attribute on the target tag of a translation unit would cause an exception. Now it properly gives an error that no state was found.