### PR TITLE
Don't produce a Result if source plural category is empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -717,6 +717,13 @@ limitations under the License.
 
 ## Release Notes
 
+### v1.6.2
+
+- fixed plural checker to not produce a result if the source plural
+  category is empty. Previously, if the source category and the target
+  category were both empty, it would complain that the target string
+  is the same as the source string.
+
 ### v1.6.1
 
 - resource-quote-style: don't emit error when quotes are missing in SV target

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-lint",
-    "version": "1.6.1",
+    "version": "1.6.2",
     "module": "./src/index.js",
     "type": "module",
     "bin": "./src/index.js",

--- a/src/rules/ResourceICUPluralTranslation.js
+++ b/src/rules/ResourceICUPluralTranslation.js
@@ -148,8 +148,9 @@ class ResourceICUPluralTranslation extends ResourceRule {
                 const targetStr = this.reconstruct(targetPlural.options[category].value).replace(/\s+/g, " ").trim();
                 let result = [];
 
-                // use case- and whitespace-insensitive match
-                if (sourceStr.toLowerCase() === targetStr.toLowerCase()) {
+                // use case- and whitespace-insensitive match. Also, don't produce a result
+                // if the source string is empty
+                if (sourceStr.length && sourceStr.toLowerCase() === targetStr.toLowerCase()) {
                     let value = {
                         severity: "warning",
                         description: `Translation of the category \'${category}\' is the same as the source.`,
@@ -195,6 +196,9 @@ class ResourceICUPluralTranslation extends ResourceRule {
         // same language and script means that the translations are allowed to be the same as
         // the source
         if (sLoc.getLangSpec() === tLoc.getLangSpec()) return;
+
+        // don't need to check target if there is no source
+        if (!source || !source.length) return;
 
         let sourceAst;
         let targetAst;

--- a/test/testResourceICUPluralTranslation.js
+++ b/test/testResourceICUPluralTranslation.js
@@ -720,5 +720,30 @@ export const testResourceICUPluralTranslation = {
         test.done();
     },
 
+    testResourceICUPluralTranslationsIgnoreEmptyCategories: function(test) {
+        test.expect(2);
+
+        const rule = new ResourceICUPluralTranslation();
+        test.ok(rule);
+
+        const actual = rule.match({
+            ir: new IntermediateRepresentation({
+                type: "resource",
+                ir: [new ResourceString({
+                    key: "plural.test",
+                    sourceLocale: "en-US",
+                    source: '{count, plural, one {# file} other {}} in the folder.',
+                    targetLocale: "de-DE",
+                    target: "{count, plural, one {# Datei} other {}} in dem Ordner.",
+                    pathName: "a/b/c.xliff"
+                })],
+                filePath: "a/b/c.xliff"
+            }),
+            file: "a/b/c.xliff"
+        });
+        test.ok(!actual);
+
+        test.done();
+    }
 };
 


### PR DESCRIPTION
- it's okay for the source string of a plural category and the target string to be the same if the source string is empty!