### PR TITLE
Cleanup: move initialization to the builtin plugin

### DIFF
--- a/src/PluginManager.js
+++ b/src/PluginManager.js
@@ -1,7 +1,7 @@
 /*
  * PluginManager.js - Load a list of plugins and maintain them
  *
- * Copyright © 2022 JEDLSoft
+ * Copyright © 2022-2023 JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,129 +26,9 @@ import ParserManager from './ParserManager.js';
 import RuleManager from './RuleManager.js';
 import RuleSet from './RuleSet.js';
 import BuiltinPlugin from './plugins/BuiltinPlugin.js';
-import AnsiConsoleFormatter from './formatters/AnsiConsoleFormatter.js';
-import ResourceICUPlurals from './rules/ResourceICUPlurals.js';
-import ResourceICUPluralTranslation from './rules/ResourceICUPluralTranslation.js';
-import ResourceQuoteStyle from './rules/ResourceQuoteStyle.js';
-import ResourceUniqueKeys from './rules/ResourceUniqueKeys.js';
-import ResourceEdgeWhitespace from './rules/ResourceEdgeWhitespace.js';
-import ResourceCompleteness from './rules/ResourceCompleteness.js';
-import ResourceDNTTerms from './rules/ResourceDNTTerms.js';
-import ResourceNoTranslation from './rules/ResourceNoTranslation.js';
-import ResourceStateChecker from './rules/ResourceStateChecker.js';
 import FixerManager from './FixerManager.js';
 
 const logger = log4js.getLogger("i18nlint.PluginManager");
-
-// built-in declarative rules
-export const regexRules = [
-    {
-        type: "resource-matcher",
-        name: "resource-url-match",
-        description: "Ensure that URLs that appear in the source string are also used in the translated string",
-        note: "URL '{matchString}' from the source string does not appear in the target string",
-        regexps: [ "((https?|github|ftps?|mailto|file|data|irc):\\/\\/)([\\da-zA-Z\\.-]+)\\.([a-zA-Z\\.]{2,6})([\\/\w\\.-]*)*\\/?" ],
-        link: "https://github.com/ilib-js/i18nlint/blob/main/docs/resource-url-match.md"
-    },
-    {
-        type: "resource-matcher",
-        name: "resource-named-params",
-        description: "Ensure that named parameters that appear in the source string are also used in the translated string",
-        note: "The named parameter '{matchString}' from the source string does not appear in the target string",
-        regexps: [ "\\{\\w+\\}" ],
-        link: "https://github.com/ilib-js/i18nlint/blob/main/docs/resource-named-params.md"
-    },
-    {
-        type: "resource-target",
-        name: "resource-no-fullwidth-latin",
-        description: "Ensure that the target does not contain any full-width Latin characters.",
-        note: "The full-width characters '{matchString}' are not allowed in the target string. Use ASCII letters instead.",
-        regexps: [ "[\\uFF21-\\uFF3A\\uFF41-\\uFF5A]+" ],
-        link: "https://github.com/ilib-js/i18nlint/blob/main/docs/resource-no-fullwidth.md"
-    },
-    {
-        type: "resource-target",
-        name: "resource-no-fullwidth-digits",
-        description: "Ensure that the target does not contain any full-width digits.",
-        note: "The full-width characters '{matchString}' are not allowed in the target string. Use ASCII digits instead.",
-        regexps: [ "[\\uFF10-\\uFF19]+" ],
-        link: "https://github.com/ilib-js/i18nlint/blob/main/docs/resource-no-fullwidth-digits.md"
-    },
-    {
-        type: "resource-target",
-        name: "resource-no-fullwidth-punctuation-subset",
-        description: "Ensure that the target does not contain specific full-width punctuation: percent sign, question mark, or exclamation mark.",
-        note: "The full-width characters '{matchString}' are not allowed in the target string. Use ASCII symbols instead.",
-        regexps: [ "[\\uFF01\\uFF05\\uFF1F]+" ],
-        link: "https://github.com/ilib-js/i18nlint/blob/main/docs/resource-no-fullwidth-punctuation-subset.md",
-        locales: "ja"
-    },
-        {
-        type: "resource-target",
-        name: "resource-no-space-between-double-and-single-byte-character",
-        description: "Ensure that the target does not contain a space character between a double-byte and single-byte character.",
-        note: "The space character is not allowed in the target string. Remove the space character.",
-        regexps: [ "[\\u3040-\\u309F\\u30A0-\\u30FF\\u4E00-\\u9FAF]\\s+[\\x00-\\xFF]|[\\x00-\\xFF]\\s+[\\u3040-\\u309F\\u30A0-\\u30FF\\u4E00-\\u9FAF]" ],
-        link: "https://github.com/ilib-js/i18nlint/blob/main/docs/resource-no-space-between-double-and-single-byte-character.md",
-        severity: "warning",
-        locales: "ja"
-    },
-    {
-        type: "resource-target",
-        name: "resource-no-halfwidth-kana-characters",
-        description: "Ensure that the target does not contain half-width kana characters.",
-        note: "The half-width kana characters are not allowed in the target string. Use full-width characters.",
-        regexps: [ "[ｧ-ﾝﾞﾟ]+" ],
-        link: "https://github.com/ilib-js/i18nlint/blob/main/docs/resource-no-halfwidth-kana-characters.md",
-        severity: "warning"
-    },
-    {
-        type: "resource-target",
-        name: "resource-no-double-byte-space",
-        description: "Ensure that the target does not contain double-byte space characters.",
-        note: "Double-byte space characters should not be used in the target string. Use ASCII symbols instead.",
-        // per https://en.wikipedia.org/wiki/Whitespace_character
-        regexps: [ "[\\u1680\\u2000\\u2001\\u2002\\u2003\\u2004\\u2005\\u2006\\u2007\\u2008\\u2009\\u200A\\u2028\\u2029\\u202F\\u205F\\u3000]+" ],
-        link: "https://github.com/ilib-js/i18nlint/blob/main/docs/resource-no-double-byte-space.md",
-        severity: "warning",
-        locales: "ja"
-    },
-    {
-        type: "resource-target",
-        name: "resource-no-space-with-fullwidth-punctuation",
-        description: "Ensure that there is no whitespace adjacent to the fullwidth punctuation characters.",
-        note: "There should be no space adjacent to fullwidth punctuation characters '{matchString}'. Remove it.",
-        regexps: [ "(\\s+[\\u3001\\u3002\\u3008-\\u3011\\u3014-\\u301B]|[\\u3001\\u3002\\u3008-\\u3011\\u3014-\\u301B]\\s+)" ],
-        link: "https://github.com/ilib-js/i18nlint/blob/main/docs/resource-no-space-with-fullwidth-punctuation.md",
-        severity: "warning"
-    },
-];
-
-// built-in ruleset that contains all the built-in rules
-export const builtInRulesets = {
-    generic: {
-        // programmatic rules
-        "resource-icu-plurals": true,
-        "resource-quote-style": true,
-        "resource-state-checker": true,
-        "resource-unique-keys": true,
-        "resource-edge-whitespace": true,
-        "resource-completeness": true,
-        "resource-no-translation": true,
-        "resource-icu-plurals-translated": true,
-
-        // declarative rules from above
-        "resource-url-match": true,
-        "resource-named-params": true,
-        "resource-no-fullwidth-latin": true,
-        "resource-no-fullwidth-digits": true,
-        "resource-no-fullwidth-punctuation-subset": true,
-        "resource-no-space-between-double-and-single-byte-character": true,
-        "resource-no-halfwidth-kana-characters": true,
-        "resource-no-double-byte-space": true,
-        "resource-no-space-with-fullwidth-punctuation": true,
-    }
-};
 
 /**
  * @private
@@ -257,20 +137,6 @@ class PluginManager {
         this.fixerMgr = new FixerManager();
         this.sourceLocale = options && options.sourceLocale;
 
-        // default rules
-        this.ruleMgr.add([
-            ResourceICUPlurals,
-            ResourceICUPluralTranslation,
-            ResourceQuoteStyle,
-            ResourceUniqueKeys,
-            ResourceEdgeWhitespace,
-            ResourceCompleteness,
-            ResourceDNTTerms,
-            ResourceNoTranslation,
-            ResourceStateChecker
-        ]);
-        this.ruleMgr.add(regexRules);
-
         if (options) {
             if (options.rulesData) {
                 this.ruleMgr.add(options.rulesData);
@@ -280,13 +146,7 @@ class PluginManager {
             }
         }
 
-        // add the default "generic" ruleset above
-        this.ruleMgr.addRuleSetDefinitions(builtInRulesets);
-
-        // install the default formatter
-        this.formatterMgr.add(AnsiConsoleFormatter);
-
-        // install the default parsers, rules, etc.
+        // install the default parsers, rules, formatters, etc.
         this.add(new BuiltinPlugin({
             getLogger: log4js.getLogger.bind(log4js)
         }));

--- a/src/plugins/BuiltinPlugin.js
+++ b/src/plugins/BuiltinPlugin.js
@@ -22,6 +22,126 @@ import { Plugin } from 'i18nlint-common';
 import XliffParser from './XliffParser.js';
 import LineParser from './LineParser.js';
 import StringParser from './StringParser.js';
+import AnsiConsoleFormatter from '../formatters/AnsiConsoleFormatter.js';
+import ResourceICUPlurals from '../rules/ResourceICUPlurals.js';
+import ResourceICUPluralTranslation from '../rules/ResourceICUPluralTranslation.js';
+import ResourceQuoteStyle from '../rules/ResourceQuoteStyle.js';
+import ResourceUniqueKeys from '../rules/ResourceUniqueKeys.js';
+import ResourceEdgeWhitespace from '../rules/ResourceEdgeWhitespace.js';
+import ResourceCompleteness from '../rules/ResourceCompleteness.js';
+import ResourceDNTTerms from '../rules/ResourceDNTTerms.js';
+import ResourceNoTranslation from '../rules/ResourceNoTranslation.js';
+import ResourceStateChecker from '../rules/ResourceStateChecker.js';
+
+// built-in declarative rules
+export const regexRules = [
+    {
+        type: "resource-matcher",
+        name: "resource-url-match",
+        description: "Ensure that URLs that appear in the source string are also used in the translated string",
+        note: "URL '{matchString}' from the source string does not appear in the target string",
+        regexps: [ "((https?|github|ftps?|mailto|file|data|irc):\\/\\/)([\\da-zA-Z\\.-]+)\\.([a-zA-Z\\.]{2,6})([\\/\w\\.-]*)*\\/?" ],
+        link: "https://github.com/ilib-js/i18nlint/blob/main/docs/resource-url-match.md"
+    },
+    {
+        type: "resource-matcher",
+        name: "resource-named-params",
+        description: "Ensure that named parameters that appear in the source string are also used in the translated string",
+        note: "The named parameter '{matchString}' from the source string does not appear in the target string",
+        regexps: [ "\\{\\w+\\}" ],
+        link: "https://github.com/ilib-js/i18nlint/blob/main/docs/resource-named-params.md"
+    },
+    {
+        type: "resource-target",
+        name: "resource-no-fullwidth-latin",
+        description: "Ensure that the target does not contain any full-width Latin characters.",
+        note: "The full-width characters '{matchString}' are not allowed in the target string. Use ASCII letters instead.",
+        regexps: [ "[\\uFF21-\\uFF3A\\uFF41-\\uFF5A]+" ],
+        link: "https://github.com/ilib-js/i18nlint/blob/main/docs/resource-no-fullwidth.md"
+    },
+    {
+        type: "resource-target",
+        name: "resource-no-fullwidth-digits",
+        description: "Ensure that the target does not contain any full-width digits.",
+        note: "The full-width characters '{matchString}' are not allowed in the target string. Use ASCII digits instead.",
+        regexps: [ "[\\uFF10-\\uFF19]+" ],
+        link: "https://github.com/ilib-js/i18nlint/blob/main/docs/resource-no-fullwidth-digits.md"
+    },
+    {
+        type: "resource-target",
+        name: "resource-no-fullwidth-punctuation-subset",
+        description: "Ensure that the target does not contain specific full-width punctuation: percent sign, question mark, or exclamation mark.",
+        note: "The full-width characters '{matchString}' are not allowed in the target string. Use ASCII symbols instead.",
+        regexps: [ "[\\uFF01\\uFF05\\uFF1F]+" ],
+        link: "https://github.com/ilib-js/i18nlint/blob/main/docs/resource-no-fullwidth-punctuation-subset.md",
+        locales: "ja"
+    },
+        {
+        type: "resource-target",
+        name: "resource-no-space-between-double-and-single-byte-character",
+        description: "Ensure that the target does not contain a space character between a double-byte and single-byte character.",
+        note: "The space character is not allowed in the target string. Remove the space character.",
+        regexps: [ "[\\u3040-\\u309F\\u30A0-\\u30FF\\u4E00-\\u9FAF]\\s+[\\x00-\\xFF]|[\\x00-\\xFF]\\s+[\\u3040-\\u309F\\u30A0-\\u30FF\\u4E00-\\u9FAF]" ],
+        link: "https://github.com/ilib-js/i18nlint/blob/main/docs/resource-no-space-between-double-and-single-byte-character.md",
+        severity: "warning",
+        locales: "ja"
+    },
+    {
+        type: "resource-target",
+        name: "resource-no-halfwidth-kana-characters",
+        description: "Ensure that the target does not contain half-width kana characters.",
+        note: "The half-width kana characters are not allowed in the target string. Use full-width characters.",
+        regexps: [ "[ｧ-ﾝﾞﾟ]+" ],
+        link: "https://github.com/ilib-js/i18nlint/blob/main/docs/resource-no-halfwidth-kana-characters.md",
+        severity: "warning"
+    },
+    {
+        type: "resource-target",
+        name: "resource-no-double-byte-space",
+        description: "Ensure that the target does not contain double-byte space characters.",
+        note: "Double-byte space characters should not be used in the target string. Use ASCII symbols instead.",
+        // per https://en.wikipedia.org/wiki/Whitespace_character
+        regexps: [ "[\\u1680\\u2000\\u2001\\u2002\\u2003\\u2004\\u2005\\u2006\\u2007\\u2008\\u2009\\u200A\\u2028\\u2029\\u202F\\u205F\\u3000]+" ],
+        link: "https://github.com/ilib-js/i18nlint/blob/main/docs/resource-no-double-byte-space.md",
+        severity: "warning",
+        locales: "ja"
+    },
+    {
+        type: "resource-target",
+        name: "resource-no-space-with-fullwidth-punctuation",
+        description: "Ensure that there is no whitespace adjacent to the fullwidth punctuation characters.",
+        note: "There should be no space adjacent to fullwidth punctuation characters '{matchString}'. Remove it.",
+        regexps: [ "(\\s+[\\u3001\\u3002\\u3008-\\u3011\\u3014-\\u301B]|[\\u3001\\u3002\\u3008-\\u3011\\u3014-\\u301B]\\s+)" ],
+        link: "https://github.com/ilib-js/i18nlint/blob/main/docs/resource-no-space-with-fullwidth-punctuation.md",
+        severity: "warning"
+    },
+];
+
+// built-in ruleset that contains all the built-in rules
+export const builtInRulesets = {
+    generic: {
+        // programmatic rules
+        "resource-icu-plurals": true,
+        "resource-quote-style": true,
+        "resource-state-checker": true,
+        "resource-unique-keys": true,
+        "resource-edge-whitespace": true,
+        "resource-completeness": true,
+        "resource-no-translation": true,
+        "resource-icu-plurals-translated": true,
+
+        // declarative rules from above
+        "resource-url-match": true,
+        "resource-named-params": true,
+        "resource-no-fullwidth-latin": true,
+        "resource-no-fullwidth-digits": true,
+        "resource-no-fullwidth-punctuation-subset": true,
+        "resource-no-space-between-double-and-single-byte-character": true,
+        "resource-no-halfwidth-kana-characters": true,
+        "resource-no-double-byte-space": true,
+        "resource-no-space-with-fullwidth-punctuation": true,
+    }
+};
 
 /**
  * @class ilib-lint plugin that can parse XLIFF files
@@ -44,6 +164,38 @@ class BuiltinPlugin extends Plugin {
      */
     getParsers() {
         return [XliffParser, LineParser, StringParser];
+    }
+
+    /**
+     * @override
+     */
+    getRules() {
+        return [
+            ResourceICUPlurals,
+            ResourceICUPluralTranslation,
+            ResourceQuoteStyle,
+            ResourceUniqueKeys,
+            ResourceEdgeWhitespace,
+            ResourceCompleteness,
+            ResourceDNTTerms,
+            ResourceNoTranslation,
+            ResourceStateChecker,
+            ...regexRules
+        ];
+    }
+
+    /**
+     * @override
+     */
+    getRuleSets() {
+        return builtInRulesets;
+    }
+
+    /**
+     * @override
+     */
+    getFormatters() {
+        return [AnsiConsoleFormatter];
     }
 };
 

--- a/test/testResourceMatcher.js
+++ b/test/testResourceMatcher.js
@@ -19,7 +19,7 @@
 import { ResourceString, ResourceArray, ResourcePlural } from 'ilib-tools-common';
 
 import ResourceMatcher from '../src/rules/ResourceMatcher.js';
-import { regexRules } from '../src/PluginManager.js';
+import { regexRules } from '../src/plugins/BuiltinPlugin.js';
 
 import { Result } from 'i18nlint-common';
 

--- a/test/testResourceTargetChecker.js
+++ b/test/testResourceTargetChecker.js
@@ -19,7 +19,7 @@
 import { ResourceString, ResourceArray, ResourcePlural } from 'ilib-tools-common';
 
 import ResourceTargetChecker from '../src/rules/ResourceTargetChecker.js';
-import { regexRules } from '../src/PluginManager.js';
+import { regexRules } from '../src/plugins/BuiltinPlugin.js';
 
 import { Result } from 'i18nlint-common';
 


### PR DESCRIPTION
- instead of initializing the built-in rules, rulesets, and formatters in the PluginManager, move the initialization into the BuiltinPlugin which is the more logical place for them to live