### PR TITLE
Fix intl-messageformat dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -726,7 +726,6 @@ limitations under the License.
     - a Fixer should be able to apply provided Fixes onto the IntermediateRepresentation
       so that a fixed content would then be written out to the file
     - auto-fixing can be enabled either via CLI flag "fix" or in project config file "autofix"
-- implemented a mechanism for fixing strings
 
 ### v1.7.0
 

--- a/README.md
+++ b/README.md
@@ -726,6 +726,7 @@ limitations under the License.
     - a Fixer should be able to apply provided Fixes onto the IntermediateRepresentation
       so that a fixed content would then be written out to the file
     - auto-fixing can be enabled either via CLI flag "fix" or in project config file "autofix"
+- implemented a mechanism for fixing strings
 
 ### v1.7.0
 

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
         "ilib-locale": "^1.2.2",
         "ilib-localeinfo": "^1.0.5",
         "ilib-tools-common": "^1.7.0",
+        "intl-messageformat": "<10.4",
         "json5": "^2.2.3",
         "log4js": "^6.9.1",
         "micromatch": "^4.0.5",


### PR DESCRIPTION
`intl-messageformat 10.4.0` update module settings have been changed - linter fails when trying to import it. This PR specifies direct linter dependency on this package version lesser than 10.4.