### PR TITLE
Fix plural checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -717,7 +717,7 @@ limitations under the License.
 
 ## Release Notes
 
-### Pending release
+### v1.8.0
 
 - added auto-fixing support
     - Parser can now implement writing out a modified IntermediateRepresentation
@@ -727,6 +727,9 @@ limitations under the License.
       so that a fixed content would then be written out to the file
     - auto-fixing can be enabled either via CLI flag "fix" or in project config file "autofix"
 - implemented a mechanism for fixing strings
+- improved ICU plural checker to be able to parse plurals properly when the plurals
+  are embedded in the middle of a string. Previously, it only checked the plurals
+  when they were they only thing in the string.
 
 ### v1.7.0
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-lint",
-    "version": "1.7.0",
+    "version": "1.8.0",
     "module": "./src/index.js",
     "type": "module",
     "bin": "./src/index.js",

--- a/src/rules/ResourceICUPlurals.js
+++ b/src/rules/ResourceICUPlurals.js
@@ -220,18 +220,18 @@ class ResourceICUPlurals extends ResourceRule {
             if (sourceSelects[select]) {
                 problems = problems.concat(this.matchCategories(sourceSelects[select], targetSelect, locale, resource));
             } else {
-                const targetSnippet = resource.getTarget();
+                const targetSnippet = resource.getTarget().replaceAll(new RegExp(`(\\{\\s*${select})`, "g"), "<e0>$1</e0>");
                 let opts = {
                     severity: "error",
                     rule: this,
                     description: `Select or plural with pivot variable ${targetSelects[select].node.value} does not exist in the source string. Possible translated variable name.`,
                     id: resource.getKey(),
-                    highlight: `Target: <e0>${targetSelect}</e0>`,
+                    highlight: `Target: ${targetSnippet}`,
                     pathName: resource.getPath(),
                     source: resource.getSource(),
                     locale: resource.getTargetLocale()
                 };
-                value.push(new Result(opts));
+                problems.push(new Result(opts));
             }
         });
 

--- a/src/rules/ResourceICUPlurals.js
+++ b/src/rules/ResourceICUPlurals.js
@@ -171,7 +171,7 @@ class ResourceICUPlurals extends ResourceRule {
             return sourceSelect.categories.indexOf(category) < 0;
         });
         if (extra.length) {
-            const highlight = resource.getTarget().replaceAll(new RegExp(`(${extra.join("|")})\\s*\\{`, "g"), "<e0>$1</e0> {");
+            const highlight = resource.getTarget().replace(new RegExp(`(${extra.join("|")})\\s*\\{`, "g"), "<e0>$1</e0> {");
             let opts = {
                 severity: "warning",
                 rule: this,
@@ -220,7 +220,7 @@ class ResourceICUPlurals extends ResourceRule {
             if (sourceSelects[select]) {
                 problems = problems.concat(this.matchCategories(sourceSelects[select], targetSelect, locale, resource));
             } else {
-                const targetSnippet = resource.getTarget().replaceAll(new RegExp(`(\\{\\s*${select})`, "g"), "<e0>$1</e0>");
+                const targetSnippet = resource.getTarget().replace(new RegExp(`(\\{\\s*${select})`, "g"), "<e0>$1</e0>");
                 let opts = {
                     severity: "error",
                     rule: this,

--- a/src/rules/ResourceICUPlurals.js
+++ b/src/rules/ResourceICUPlurals.js
@@ -187,7 +187,7 @@ class ResourceICUPlurals extends ResourceRule {
 
         return problems;
     }
-    
+
     findSelects(ast) {
         let selects = {};
 
@@ -209,12 +209,12 @@ class ResourceICUPlurals extends ResourceRule {
 
         return selects;
     }
-    
+
     checkNodes(sourceAst, targetAst, locale, resource) {
         const sourceSelects = this.findSelects(sourceAst);
         const targetSelects = this.findSelects(targetAst);
         let problems = [];
-        
+
         Object.keys(targetSelects).forEach(select => {
             const targetSelect = targetSelects[select];
             if (sourceSelects[select]) {
@@ -234,7 +234,7 @@ class ResourceICUPlurals extends ResourceRule {
                 value.push(new Result(opts));
             }
         });
-        
+
         return problems;
     }
 

--- a/test/testResourceICUPlurals.js
+++ b/test/testResourceICUPlurals.js
@@ -264,6 +264,32 @@ export const testResourceICUPlurals = {
         test.done();
     },
 
+    testResourceICUPluralsMatchMissingCategoriesInTargetAlsoMissingInSource: function(test) {
+        test.expect(2);
+
+        const rule = new ResourceICUPlurals();
+        test.ok(rule);
+
+        const resource = new ResourceString({
+            key: "plural.test",
+            sourceLocale: "en-US",
+            source: '{count, plural, =1 {This is singular} other {This is plural}}', // missing the "one" category
+            targetLocale: "ru-RU",
+            target: "{count, plural, =1 {Это единственное число} few {это множественное число} other {это множественное число}}",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        // ignore the target problem when there is a source problem
+        test.ok(!actual);
+
+        test.done();
+    },
+
     testResourceICUPluralsMatchMissingCategoriesInSource: function(test) {
         test.expect(2);
 
@@ -686,6 +712,188 @@ export const testResourceICUPlurals = {
             pathName: "a/b/c.xliff",
             locale: "de-DE",
             source: '{count, select, male {He said} female {She said} other {They said}}'
+        });
+        test.deepEqual(actual, expected);
+
+        test.done();
+    },
+
+    testResourceICUPluralsEmbeddedPluralNoError: function(test) {
+        test.expect(2);
+
+        const rule = new ResourceICUPlurals();
+        test.ok(rule);
+
+        const resource = new ResourceString({
+            key: "plural.test",
+            sourceLocale: "en-US",
+            source: 'The file is located in {count, plural, one {# collection} other {# collections}} visible to user {name}.' ,
+            targetLocale: "de-DE",
+            target: "Die Datei befindet sich in {count, plural, one {# Sammlung} other {# Sammlungen}} die für Benutzer {name} sichtbar ist.",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        test.ok(!actual);
+
+        test.done();
+    },
+
+    testResourceICUPluralsEmbeddedPluralMissingClosingBrace: function(test) {
+        test.expect(2);
+
+        const rule = new ResourceICUPlurals();
+        test.ok(rule);
+
+        const resource = new ResourceString({
+            key: "plural.test",
+            sourceLocale: "en-US",
+            source: 'The file is located in {count, plural, one {# collection} other {# collections}} visible to user {name}.' ,
+            targetLocale: "de-DE",
+            target: "Die Datei befindet sich in {count, plural, one {# Sammlung} other {# Sammlungen} die für Benutzer {name} sichtbar ist.",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        const expected = new Result({
+            severity: "error",
+            description: "Incorrect plural or select syntax in target string: SyntaxError: EXPECT_PLURAL_ARGUMENT_SELECTOR_FRAGMENT",
+            id: "plural.test",
+            highlight: 'Target: Die Datei befindet sich in {count, plural, one {# Sammlung} other {# Sammlungen} die <e0>für Benutzer {name} sichtbar ist.</e0>',
+            rule,
+            pathName: "a/b/c.xliff",
+            locale: "de-DE",
+            source: 'The file is located in {count, plural, one {# collection} other {# collections}} visible to user {name}.'
+        });
+        test.deepEqual(actual, expected);
+
+        test.done();
+    },
+
+    testResourceICUPluralsEmbeddedPluralIgnoreSourceProblems: function(test) {
+        test.expect(2);
+
+        const rule = new ResourceICUPlurals();
+        test.ok(rule);
+
+        const resource = new ResourceString({
+            key: "plural.test",
+            sourceLocale: "en-US",
+            source: 'The file is located in {count, plural, one {# collection} other {# collections} visible to user {name}.' ,
+            targetLocale: "de-DE",
+            target: "Die Datei befindet sich in {count, plural, one {# Sammlung} other {# Sammlungen} die für Benutzer {name} sichtbar ist.",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        // no results because there was a syntax error in the source -- we don't even check the target in that case
+        test.ok(!actual);
+
+        test.done();
+    },
+
+
+    testResourceICUPluralsEmbeddedMatchTranslatedCategoriesNoError: function(test) {
+        test.expect(2);
+
+        const rule = new ResourceICUPlurals();
+        test.ok(rule);
+
+        const resource = new ResourceString({
+            key: "plural.test",
+            sourceLocale: "en-US",
+            source: 'This is {count, plural, one {singular} other {plural}}',
+            targetLocale: "de-DE",
+            target: "Dies ist {count, plural, one {einzigartig} other {mehrerartig}}",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        test.ok(!actual);
+
+        test.done();
+    },
+
+    testResourceICUPluralsEmbeddedMatchTranslatedCategoriesMissingCategories: function(test) {
+        test.expect(2);
+
+        const rule = new ResourceICUPlurals();
+        test.ok(rule);
+
+        const resource = new ResourceString({
+            key: "plural.test",
+            sourceLocale: "en-US",
+            source: 'This is {count, plural, one {singular} other {plural}}',
+            targetLocale: "de-DE",
+            target: "Dies ist {count, plural, eins {einzigartig} andere {mehrerartig}}", // category names should not be translated!
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        const expected = new Result({
+            severity: "error",
+            description: "Incorrect plural or select syntax in target string: SyntaxError: MISSING_OTHER_CLAUSE",
+            id: "plural.test",
+            source: 'This is {count, plural, one {singular} other {plural}}',
+            highlight: 'Target: Dies ist {count, plural, eins {einzigartig} andere {mehrerartig}<e0>}</e0>',
+            rule,
+            locale: "de-DE",
+            pathName: "a/b/c.xliff"
+        });
+        test.deepEqual(actual, expected);
+
+        test.done();
+    },
+
+    testResourceICUPluralsEmbeddedMatchMissingCategoriesInTarget: function(test) {
+        test.expect(2);
+
+        const rule = new ResourceICUPlurals();
+        test.ok(rule);
+
+        const resource = new ResourceString({
+            key: "plural.test",
+            sourceLocale: "en-US",
+            source: 'This is {count, plural, one {singular} other {plural}}',
+            targetLocale: "ru-RU",
+            target: "Это {count, plural, one {единственное число} other {множественное число}}",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        const expected = new Result({
+            severity: "error",
+            description: "Missing categories in target string: few. Expecting these: one, few, other",
+            id: "plural.test",
+            source: 'This is {count, plural, one {singular} other {plural}}',
+            highlight: 'Target: Это {count, plural, one {единственное число} other {множественное число}}<e0></e0>',
+            rule,
+            locale: "ru-RU",
+            pathName: "a/b/c.xliff"
         });
         test.deepEqual(actual, expected);
 

--- a/test/testResourceICUPlurals.js
+++ b/test/testResourceICUPlurals.js
@@ -899,5 +899,40 @@ export const testResourceICUPlurals = {
 
         test.done();
     },
+
+    testResourceICUPluralsTranslatedPivotVariable: function(test) {
+        test.expect(2);
+
+        const rule = new ResourceICUPlurals();
+        test.ok(rule);
+
+        const resource = new ResourceString({
+            key: "plural.test",
+            sourceLocale: "en-US",
+            source: 'This is {count, plural, one {singular} other {plural}}',
+            targetLocale: "ru-RU",
+            target: "Это {считать, plural, one {единственное число} few {множественное число} other {множественное число}}",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        const expected = new Result({
+            severity: "error",
+            description: "Select or plural with pivot variable считать does not exist in the source string. Possible translated variable name.",
+            id: "plural.test",
+            source: 'This is {count, plural, one {singular} other {plural}}',
+            highlight: 'Target: Это <e0>{считать</e0>, plural, one {единственное число} few {множественное число} other {множественное число}}',
+            rule,
+            locale: "ru-RU",
+            pathName: "a/b/c.xliff"
+        });
+        test.deepEqual(actual, expected);
+
+        test.done();
+    }
 };
 

--- a/test/testResourceICUPlurals.js
+++ b/test/testResourceICUPlurals.js
@@ -338,7 +338,7 @@ export const testResourceICUPlurals = {
             severity: "warning",
             description: "Extra categories in target string: few. Expecting only these: one, other",
             id: "plural.test",
-            highlight: 'Target: {count, plural, one {Dies ist einzigartig} few {This is few} other {Dies ist mehrerartig}}<e0></e0>',
+            highlight: 'Target: {count, plural, one {Dies ist einzigartig} <e0>few</e0> {This is few} other {Dies ist mehrerartig}}',
             rule,
             pathName: "a/b/c.xliff",
             locale: "de-DE",
@@ -395,7 +395,7 @@ export const testResourceICUPlurals = {
             file: "a/b/c.xliff"
         });
         const expected = new Result({
-            severity: "error",
+            severity: "warning",
             description: "Missing categories in target string: =1. Expecting these: one, other, =1",
             id: "plural.test",
             highlight: 'Target: {count, plural, one {Dies ist einzigartig} other {Dies ist mehrerartig}}<e0></e0>',
@@ -704,7 +704,7 @@ export const testResourceICUPlurals = {
             file: "a/b/c.xliff"
         });
         const expected = new Result({
-            severity: "error",
+            severity: "warning",
             description: "Missing categories in target string: female. Expecting these: other, male, female",
             id: "plural.test",
             highlight: 'Target: {count, select, male {Er sagt} other {Ihnen sagen}}<e0></e0>',


### PR DESCRIPTION
- rewrite the plural checker
    - if the source has a syntax error, don't check the target (because we don't have something valid to check against!)
    - now traverses the ast recursively, looking at nested selects/plurals at each level
    - can deal with multiple independent or consecutive plurals at the same level
    - finds the missing or extra plural categories in the target only. If the source is incorrect, errors are not reported. (It is up to the source checker to report on errors in the source.)