### PR TITLE
Unit test to show Dutch quote checking is working properly

### DIFF
--- a/test/testResourceQuoteStyle.js
+++ b/test/testResourceQuoteStyle.js
@@ -294,6 +294,31 @@ export const testResourceQuoteStyle = {
         test.done();
     },
 
+    testResourceQuoteStyleMatchAsciiQuotesDutch: function(test) {
+        test.expect(2);
+
+        const rule = new ResourceQuoteStyle();
+        test.ok(rule);
+
+        const resource = new ResourceString({
+            key: "quote.test",
+            sourceLocale: "en-US",
+            source: 'This string contains "quotes" in it.',
+            targetLocale: "nl-NL",
+            target: "Deze string bevat ‘aanhalingstekens’.",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        test.ok(!actual);
+
+        test.done();
+    },
+
     testResourceQuoteStyleMatchAlternate: function(test) {
         test.expect(2);
 


### PR DESCRIPTION
I thought the quote checker was not working properly because when you search in chrome for straight ASCII single quote, it matches the "extended" nine and six single quotes as well even though they are not the same character. However, when you use a different tool to look at the linter output that does not overmatch, it turns out that the xliffs were indeed not using the correct quotes and the linter output was accurate.

This PR adds a new unit test to verify that it is working properly for Dutch. No code change needed.