### PR TITLE
Add in rule to check for "lazy" plurals

### DIFF
--- a/docs/source-no-lazy-plurals.md
+++ b/docs/source-no-lazy-plurals.md
@@ -1,0 +1,33 @@
+# source-no-lazy-plurals
+
+Ensure that source strings do not contain "lazy" plurals. A lazy plural
+is where you put the construct "(s)" at the end of a word to indicate that
+the number may be singular or plural. Even in English, this looks a little
+awkward because it looks like you didn't put the effort to get it right,
+and also sometimes the plurality of the verb does not correspond to the
+given number. In other languages with complex plural systems or where
+pluralizing a word involves spelling changes in mid-word, it is close to
+impossible to translate it properly.
+
+German:
+
+"Auto" (car) -> "Autos" (cars)  add an "s" suffix
+"Tisch" (table) -> "Tische" (tables)  add an "e" suffix
+"Fuß" (foot) -> "Füße" (feet) add an "e" and modify the central vowel
+"Bäcker" (baker) -> "Bäcker" (bakers)  no suffix for this plural
+
+Instead, you should use the proper plural syntax for your i18n library.
+React-intl, for example, uses the ICU messageformat syntax as in this
+example:
+
+Bad source string:
+
+```
+There are {num} name(s).
+```
+
+Preferred source string:
+
+```
+{num, plural, one {There is {num} name.} other {There are {num} names.}}
+```

--- a/src/plugins/BuiltinPlugin.js
+++ b/src/plugins/BuiltinPlugin.js
@@ -146,6 +146,15 @@ export const regexRules = [
         regexps: [ "(?:^|[^'])(?<match>\\{[^}]*?-[^}]*\\})" ],
         link: "https://github.com/ilib-js/i18nlint/blob/main/docs/source-no-dashes-in-replacement-params.md",
         severity: "error"
+    },
+    {
+        type: "resource-source",
+        name: "source-no-lazy-plurals",
+        description: "Ensure that source strings do not contain the (s) construct to indicate a possible plural. That is not translatable to many languages.",
+        note: "The (s) construct is not allowed in source strings. Use real plural syntax instead.",
+        regexps: [ "(?<match>\\w+\\(s\\))(?:\\s|\\p{P}|$)" ],  // \p{P} means punctuation
+        link: "https://github.com/ilib-js/i18nlint/blob/main/docs/source-no-lazy-plurals.md",
+        severity: "warning"
     }
 ];
 
@@ -179,7 +188,8 @@ export const builtInRulesets = {
         "resource-source-icu-plural-syntax": true,
         "resource-source-icu-plural-categories": true,
         "source-no-escaped-curly-braces": true,
-        "source-no-dashes-in-replacement-params": true
+        "source-no-dashes-in-replacement-params": true,
+        "source-no-lazy-plurals": true
     },
 };
 

--- a/test/testResourceNoLazyPlurals.js
+++ b/test/testResourceNoLazyPlurals.js
@@ -1,0 +1,256 @@
+/*
+ * testResourceNoLazyPlurals.js - test the built-in regular-expression-based rules
+ *
+ * Copyright © 2023 JEDLSoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ResourceString, ResourceArray, ResourcePlural } from 'ilib-tools-common';
+
+import ResourceSourceChecker from '../src/rules/ResourceSourceChecker.js';
+import { regexRules } from '../src/plugins/BuiltinPlugin.js';
+
+import { Result } from 'i18nlint-common';
+
+function findRuleDefinition(name) {
+    return regexRules.find(rule => rule.name === name);
+}
+
+export const testResourceNoLazyPlurals = {
+    testResourceLazyPluralString: function(test) {
+        test.expect(8);
+
+        const rule = new ResourceSourceChecker(findRuleDefinition("source-no-lazy-plurals"));
+        test.ok(rule);
+
+        const resource = new ResourceString({
+            key: "matcher.test",
+            sourceLocale: "en-US",
+            source: "There are {num} file(s) in the folder.",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        test.ok(actual);
+        test.equal(actual.length, 1);
+
+        test.equal(actual[0].severity, "warning");
+        test.equal(actual[0].id, "matcher.test");
+        test.equal(actual[0].description, "The (s) construct is not allowed in source strings. Use real plural syntax instead.");
+        test.equal(actual[0].highlight, "Source: There are {num} <e0>file(s)</e0> in the folder.");
+        test.equal(actual[0].pathName, "a/b/c.xliff");
+
+        test.done();
+    },
+
+    testResourceNoLazyPluralString: function(test) {
+        test.expect(2);
+
+        const rule = new ResourceSourceChecker(findRuleDefinition("source-no-lazy-plurals"));
+        test.ok(rule);
+
+        const resource = new ResourceString({
+            key: "matcher.test",
+            sourceLocale: "en-US",
+            source: "There are {num} file in the folder.",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        test.ok(!actual);
+
+        test.done();
+    },
+
+    testResourceNoLazyPluralMidWordString: function(test) {
+        test.expect(2);
+
+        const rule = new ResourceSourceChecker(findRuleDefinition("source-no-lazy-plurals"));
+        test.ok(rule);
+
+        const resource = new ResourceString({
+            key: "matcher.test",
+            sourceLocale: "en-US",
+            source: "There are {num} file(s)asdf in the folder.",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        test.ok(!actual);
+
+        test.done();
+    },
+
+    testResourceNoLazyPluralNotPluralString: function(test) {
+        test.expect(2);
+
+        const rule = new ResourceSourceChecker(findRuleDefinition("source-no-lazy-plurals"));
+        test.ok(rule);
+
+        // no word before the (s) means no match
+        const resource = new ResourceString({
+            key: "matcher.test",
+            sourceLocale: "en-US",
+            source: "There are {num} file (s) in the folder.",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        test.ok(!actual);
+
+        test.done();
+    },
+
+    testResourceLazyPluralEndOfString: function(test) {
+        test.expect(8);
+
+        const rule = new ResourceSourceChecker(findRuleDefinition("source-no-lazy-plurals"));
+        test.ok(rule);
+
+        const resource = new ResourceString({
+            key: "matcher.test",
+            sourceLocale: "en-US",
+            source: "There are {num} files in {folderNum} folder(s)",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        test.ok(actual);
+        test.equal(actual.length, 1);
+
+        test.equal(actual[0].severity, "warning");
+        test.equal(actual[0].id, "matcher.test");
+        test.equal(actual[0].description, "The (s) construct is not allowed in source strings. Use real plural syntax instead.");
+        test.equal(actual[0].highlight, "Source: There are {num} files in {folderNum} <e0>folder(s)</e0>");
+        test.equal(actual[0].pathName, "a/b/c.xliff");
+
+        test.done();
+    },
+
+    testResourceLazyPluralBeginningOfString: function(test) {
+        test.expect(8);
+
+        const rule = new ResourceSourceChecker(findRuleDefinition("source-no-lazy-plurals"));
+        test.ok(rule);
+
+        const resource = new ResourceString({
+            key: "matcher.test",
+            sourceLocale: "en-US",
+            source: "File(s) deleted",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        test.ok(actual);
+        test.equal(actual.length, 1);
+
+        test.equal(actual[0].severity, "warning");
+        test.equal(actual[0].id, "matcher.test");
+        test.equal(actual[0].description, "The (s) construct is not allowed in source strings. Use real plural syntax instead.");
+        test.equal(actual[0].highlight, "Source: <e0>File(s)</e0> deleted");
+        test.equal(actual[0].pathName, "a/b/c.xliff");
+
+        test.done();
+    },
+
+    testResourceLazyPluralMultipleString: function(test) {
+        test.expect(13);
+
+        const rule = new ResourceSourceChecker(findRuleDefinition("source-no-lazy-plurals"));
+        test.ok(rule);
+
+        const resource = new ResourceString({
+            key: "matcher.test",
+            sourceLocale: "en-US",
+            source: "There are {num} file(s) in the folder(s)",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        test.ok(actual);
+        test.equal(actual.length, 2);
+
+        test.equal(actual[0].severity, "warning");
+        test.equal(actual[0].id, "matcher.test");
+        test.equal(actual[0].description, "The (s) construct is not allowed in source strings. Use real plural syntax instead.");
+        test.equal(actual[0].highlight, "Source: There are {num} <e0>file(s)</e0> in the folder(s)");
+        test.equal(actual[0].pathName, "a/b/c.xliff");
+
+        test.equal(actual[1].severity, "warning");
+        test.equal(actual[1].id, "matcher.test");
+        test.equal(actual[1].description, "The (s) construct is not allowed in source strings. Use real plural syntax instead.");
+        test.equal(actual[1].highlight, "Source: There are {num} file(s) in the <e0>folder(s)</e0>");
+        test.equal(actual[1].pathName, "a/b/c.xliff");
+
+        test.done();
+    },
+
+    testResourceLazyPluralEndingInPunctString: function(test) {
+        test.expect(8);
+
+        const rule = new ResourceSourceChecker(findRuleDefinition("source-no-lazy-plurals"));
+        test.ok(rule);
+
+        const resource = new ResourceString({
+            key: "matcher.test",
+            sourceLocale: "en-US",
+            source: "There are {num} file(s).",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        test.ok(actual);
+        test.equal(actual.length, 1);
+
+        test.equal(actual[0].severity, "warning");
+        test.equal(actual[0].id, "matcher.test");
+        test.equal(actual[0].description, "The (s) construct is not allowed in source strings. Use real plural syntax instead.");
+        test.equal(actual[0].highlight, "Source: There are {num} <e0>file(s)</e0>.");
+        test.equal(actual[0].pathName, "a/b/c.xliff");
+
+        test.done();
+    }
+};

--- a/test/testSuiteFiles.js
+++ b/test/testSuiteFiles.js
@@ -30,6 +30,7 @@ const files = [
     "testResourceMatcher.js",
     "testResourceNoDashesInReplacement.js",
     "testResourceNoEscapedCurlyBraces.js",
+    "testResourceNoLazyPlurals.js",
     "testResourceNoTranslation.js",
     "testResourceQuoteStyle.js",
     "testResourceSourceICUPluralSyntax.js",


### PR DESCRIPTION
- this is where the engineer or designer got lazy and put "(s)" at the end of the word to indicate that the number of items may be singular or plural instead of using actual plural syntax