### PR TITLE
Added new rule to check for manually formatted percentages

### DIFF
--- a/README.md
+++ b/README.md
@@ -721,6 +721,9 @@ limitations under the License.
 
 - added rule source-no-dashes-in-replacement-params to check that replacement
   parameter do not contain dashes, which is not allowed in ICU syntax.
+- added rule source-no-manual-percentage-formatting to check that source
+  string do not contain manually formatted percentages. Tell the engineer to
+  use a locale-sensitive number formatter instead.
 
 ### v1.9.0
 

--- a/docs/source-no-manual-percentage-formatting.md
+++ b/docs/source-no-manual-percentage-formatting.md
@@ -1,0 +1,42 @@
+# source-no-manual-percentage-formatting
+
+Ensure that source strings do not contain manually formatted percentages.
+Percentages should be formatted with a locale-sensitive number formatter,
+such as the `FormattedNumber` component in react-intl, and the result
+should be substituted into the current string. Most number formatters can
+format basic numbers, percentages, or a currency amounts and there is
+usually a "style" parameter that selects which one of those the caller needs.
+
+Bad source string:
+
+```
+{pctFiles}% of files uploaded.
+```
+
+Preferred source string:
+
+```
+{pctFiles} of files uploaded.
+```
+
+Where the pctFiles is formatted by a number formatter and the result
+substituted into the string.
+
+Example in React with react-intl:
+
+```js
+const messages = defineMessages({
+    percentUploaded: {
+        id: "unique.id",
+        description: "Status message showing the user how much of the requested files have been uploaded so far.",
+        defaultMessage: "{pctFiles} of files uploaded."
+    }
+});
+
+<FormattedMessage ...messages.percentUploaded values={{
+    pctFiles: <FormattedNumber
+        value={numUploaded/totalRequest}
+        style="percent"
+    />
+}}/>
+```

--- a/src/plugins/BuiltinPlugin.js
+++ b/src/plugins/BuiltinPlugin.js
@@ -155,6 +155,15 @@ export const regexRules = [
         regexps: [ "(?<match>\\w+\\(s\\))(?:\\s|\\p{P}|$)" ],  // \p{P} means punctuation
         link: "https://github.com/ilib-js/i18nlint/blob/main/docs/source-no-lazy-plurals.md",
         severity: "warning"
+    },
+    {
+        type: "resource-source",
+        name: "source-no-manual-percentage-formatting",
+        description: "Ensure that source strings do not contain percentage formatting. Percentages should be formatted using a locale-sensitive number formatter instead.",
+        note: "Do not format percentages in English strings. Use a locale-sensitive number formatter and substitute the result of that into this string.",
+        regexps: [ "(?<match>\\{[\\w_.$0-9]+\\}\\s*%)(\\s|$)" ],
+        link: "https://github.com/ilib-js/i18nlint/blob/main/docs/source-no-manual-percentage-formatting.md",
+        severity: "warning"
     }
 ];
 
@@ -189,7 +198,8 @@ export const builtInRulesets = {
         "resource-source-icu-plural-categories": true,
         "source-no-escaped-curly-braces": true,
         "source-no-dashes-in-replacement-params": true,
-        "source-no-lazy-plurals": true
+        "source-no-lazy-plurals": true,
+        "source-no-manual-percentage-formatting": true
     },
 };
 

--- a/test/testResourceNoManualPercentFormatting.js
+++ b/test/testResourceNoManualPercentFormatting.js
@@ -1,0 +1,212 @@
+/*
+ * testResourceNoManualPercentFormatting.js - test the built-in regular-expression-based rules
+ *
+ * Copyright © 2023 JEDLSoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ResourceString, ResourceArray, ResourcePlural } from 'ilib-tools-common';
+
+import ResourceSourceChecker from '../src/rules/ResourceSourceChecker.js';
+import { regexRules } from '../src/plugins/BuiltinPlugin.js';
+
+import { Result } from 'i18nlint-common';
+
+function findRuleDefinition(name) {
+    return regexRules.find(rule => rule.name === name);
+}
+
+export const testResourceNoManualPercentageFormatting = {
+    testResourceManualPercentFormatting: function(test) {
+        test.expect(8);
+
+        const rule = new ResourceSourceChecker(findRuleDefinition("source-no-manual-percentage-formatting"));
+        test.ok(rule);
+
+        const resource = new ResourceString({
+            key: "matcher.test",
+            sourceLocale: "en-US",
+            source: "It is {num}% done.",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        test.ok(actual);
+        test.equal(actual.length, 1);
+
+        test.equal(actual[0].severity, "warning");
+        test.equal(actual[0].id, "matcher.test");
+        test.equal(actual[0].description, "Do not format percentages in English strings. Use a locale-sensitive number formatter and substitute the result of that into this string.");
+        test.equal(actual[0].highlight, "Source: It is <e0>{num}%</e0> done.");
+        test.equal(actual[0].pathName, "a/b/c.xliff");
+
+        test.done();
+    },
+
+    testResourceNoManualPercentFormatting: function(test) {
+        test.expect(2);
+
+        const rule = new ResourceSourceChecker(findRuleDefinition("source-no-manual-percentage-formatting"));
+        test.ok(rule);
+
+        const resource = new ResourceString({
+            key: "matcher.test",
+            sourceLocale: "en-US",
+            source: "It is {num} done.",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        test.ok(!actual);
+
+        test.done();
+    },
+
+    testResourceManualPercentFormattingWithWhitespace: function(test) {
+        test.expect(8);
+
+        const rule = new ResourceSourceChecker(findRuleDefinition("source-no-manual-percentage-formatting"));
+        test.ok(rule);
+
+        const resource = new ResourceString({
+            key: "matcher.test",
+            sourceLocale: "en-US",
+            source: "It is {num} % done.",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        test.ok(actual);
+        test.equal(actual.length, 1);
+
+        test.equal(actual[0].severity, "warning");
+        test.equal(actual[0].id, "matcher.test");
+        test.equal(actual[0].description, "Do not format percentages in English strings. Use a locale-sensitive number formatter and substitute the result of that into this string.");
+        test.equal(actual[0].highlight, "Source: It is <e0>{num} %</e0> done.");
+        test.equal(actual[0].pathName, "a/b/c.xliff");
+
+        test.done();
+    },
+
+    testResourcePercentNotAfterParam1: function(test) {
+        test.expect(2);
+
+        const rule = new ResourceSourceChecker(findRuleDefinition("source-no-manual-percentage-formatting"));
+        test.ok(rule);
+
+        const resource = new ResourceString({
+            key: "matcher.test",
+            sourceLocale: "en-US",
+            source: "It is 20% done.",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        test.ok(!actual);
+
+        test.done();
+    },
+
+    testResourcePercentNotAfterParam2: function(test) {
+        test.expect(2);
+
+        const rule = new ResourceSourceChecker(findRuleDefinition("source-no-manual-percentage-formatting"));
+        test.ok(rule);
+
+        const resource = new ResourceString({
+            key: "matcher.test",
+            sourceLocale: "en-US",
+            source: "It is %{num} done.",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        test.ok(!actual);
+
+        test.done();
+    },
+
+    testResourcePercentNotAfterParam2: function(test) {
+        test.expect(2);
+
+        const rule = new ResourceSourceChecker(findRuleDefinition("source-no-manual-percentage-formatting"));
+        test.ok(rule);
+
+        const resource = new ResourceString({
+            key: "matcher.test",
+            sourceLocale: "en-US",
+            source: "%{fileCount} files are in %{folderCount} folders.",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        test.ok(!actual);
+
+        test.done();
+    },
+
+    testResourceManualPercentFormattingCrazyParamName: function(test) {
+        test.expect(8);
+
+        const rule = new ResourceSourceChecker(findRuleDefinition("source-no-manual-percentage-formatting"));
+        test.ok(rule);
+
+        const resource = new ResourceString({
+            key: "matcher.test",
+            sourceLocale: "en-US",
+            source: "It is {numCapital_$foo.bar}% done.",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        test.ok(actual);
+        test.equal(actual.length, 1);
+
+        test.equal(actual[0].severity, "warning");
+        test.equal(actual[0].id, "matcher.test");
+        test.equal(actual[0].description, "Do not format percentages in English strings. Use a locale-sensitive number formatter and substitute the result of that into this string.");
+        test.equal(actual[0].highlight, "Source: It is <e0>{numCapital_$foo.bar}%</e0> done.");
+        test.equal(actual[0].pathName, "a/b/c.xliff");
+
+        test.done();
+    }
+};

--- a/test/testSuiteFiles.js
+++ b/test/testSuiteFiles.js
@@ -31,6 +31,7 @@ const files = [
     "testResourceNoDashesInReplacement.js",
     "testResourceNoEscapedCurlyBraces.js",
     "testResourceNoLazyPlurals.js",
+    "testResourceNoManualPercentFormatting.js",
     "testResourceNoTranslation.js",
     "testResourceQuoteStyle.js",
     "testResourceSourceICUPluralSyntax.js",


### PR DESCRIPTION
- tell the engineer to use a locale-sensitive number formatter instead and substitute the result of that into this string