### PR TITLE
New rule to check for noun replacement params

### DIFF
--- a/README.md
+++ b/README.md
@@ -717,6 +717,13 @@ limitations under the License.
 
 ## Release Notes
 
+### v1.11.0
+
+- added source-no-noun-replacement-params rule to check if a noun is being
+  substituted into a replacement parameter in the source English text. Nouns
+  and the articles "a", "an", and "the" are not translatable to all languages
+  because of gender and plurality agreement rules.
+
 ### v1.10.0
 
 - added rule source-no-dashes-in-replacement-params to check that replacement

--- a/docs/source-no-noun-replacement-params.md
+++ b/docs/source-no-noun-replacement-params.md
@@ -15,52 +15,52 @@ There are two possible scenarios for the value of the replacement parameter, and
 fix for them is different in each scenario.
 
 1. If the replacement parameter has a value from a fixed list of known possibilities,
-then create a separate string for each of those possibilities.
+   then create a separate string for each of those possibilities.
 
-For example, let's say that "fileType" in the first example above has the possible values
-of "file" and "folder". In this case, create two separate strings and select the
-applicable entire string in your code:
+   For example, let's say that "fileType" in the first example above has the possible values
+   of "file" and "folder". In this case, create two separate strings and select the
+   applicable entire string in your code:
 
-```plaintext
-Delete the file.
-Delete the folder.
-```
+   ```plaintext
+   Delete the file.
+   Delete the folder.
+   ```
 
-Code in React:
+   Code in React:
 
-```javascript
-    import messages from './messages.js';
-
-    const messageMap = {
-        "file": messages.delete.file,
-        "folder": messages.delete.folder
-    };
-    const deleteObjString = messageMap[objectToDelete.type];
-
-    [...]
-        <MyDialog type="delete">
-            <FormattedMessage {...deleteObjString} />
-        </MyDialog>
-```
-
-As an engineer, you may think that sharing the string is more efficient, as both strings
-are exactly the same except for the one word, but you are not really saving a lot of
-memory or disk footprint, and instead you are creating an untranslatable string.
+    ```javascript
+        import messages from './messages.js';
+    
+        const messageMap = {
+            "file": messages.delete.file,
+            "folder": messages.delete.folder
+        };
+        const deleteObjString = messageMap[objectToDelete.type];
+    
+        [...]
+            <MyDialog type="delete">
+                <FormattedMessage {...deleteObjString} />
+            </MyDialog>
+    ```
+    
+    As an engineer, you may think that sharing the string is more efficient, as both strings
+    are exactly the same except for the one word, but you are not really saving a lot of
+    memory or disk footprint, and instead you are creating an untranslatable string.
 
 2. If the replacement parameter has an unknown value that is possibly user-entered or
-from a 3rd party library or service, the way you avoid this problem is to make the string
-ungrammatical. That is, you still substitute the value into the string, but you make
-sure that the text being substituted is not grammatically related to the rest of the
-string.
-
-Here is the first example again, but expressed in a non-grammatical way.
-
-```plaintext
-Delete an object with this type: {fileType}
-```
-
-Now when you substitute in any word for "fileType", the rest of the string does not need
-to agree with the plurality or gender of the value of "fileType".
+    from a 3rd party library or service, the way you avoid this problem is to make the string
+    ungrammatical. That is, you still substitute the value into the string, but you make
+    sure that the text being substituted is not grammatically related to the rest of the
+    string.
+    
+    Here is the first example again, but expressed in a non-grammatical way.
+    
+    ```plaintext
+    Delete an object with this type: {fileType}
+    ```
+    
+    Now when you substitute in any word for "fileType", the rest of the string does not need
+    to agree with the plurality or gender of the value of "fileType".
 
 ## Why does this rule exist?
 

--- a/docs/source-no-noun-replacement-params.md
+++ b/docs/source-no-noun-replacement-params.md
@@ -1,69 +1,109 @@
 # source-no-noun-replacement-params
 
 Ensure that source strings do not contain replacement parameters where nouns, noun
-phrases, or adjectives are substituted in to the string. The reason is that the
-spelling of the nouns and adjectives can vary with the linguistic case of that
-part of the sentence. Also, the spelling of the translations of the definite and
-indefinite articles "a", "an", and "the" varies with the gender and plurality of
-the noun or noun phrase being substituted in.
+phrases, or adjectives are substituted in to the string. That is, do not create
+strings where replacement parameters are preceded by "the", "an", or "a".
 
 Examples of bad source strings:
 
-```
-Delete the {fileType}.
-Would you like to create a new {fileType} file?
-The {object} has been sent successfully to your company's admin for review.
+```plaintext
+Delete the {fileType}.   (where fileType is a noun)
+Would you like to create a {fileType} file?     (where fileType is an adjective)
 ```
 
-Very often, the noun, noun phrase or adjective being substituted in has a
-fixed list of possible values. If you are like most engineers, you are probably
-always thinking about how you can write your code to be efficient in terms of memory
-usage, so it seems like it would be better to have one string with a substitution
-rather than two or more separate strings that are almost exactly the same except for
-one word. Only problem is, this optimization messes up translation.
+There are two possible scenarios for the value of the replacement parameter, and the
+fix for them is different in each scenario.
 
-Let's examine the first example above. In that example, the list of possible
-values for the variable fileType is "file" and "folder". That's it. Just two. So
-you might be tempted to use the string above rather than the two strings below:
+1. If the replacement parameter has a value from a fixed list of known possibilities,
+then create a separate string for each of those possibilities.
 
-```
+For example, let's say that "fileType" in the first example above has the possible values
+of "file" and "folder". In this case, create two separate strings and select the
+applicable entire string in your code:
+
+```plaintext
 Delete the file.
 Delete the folder.
 ```
 
-The only problem with substituting the noun into that spot is that there is no
-way to translate the word "the" properly to all languages, as well as the words
-"file" and "folder" to fit the linguistic case. In some languages,
-the translation for the word "file" is one gender (either masculine, feminine,
-neutral, or ungendered), whereas the translation for the word "folder" has a
-different gender. And to make matters more complicated, the gender of those
-same two words is different in different languages, even in closely related
-languages such as Spanish, Portuguese, and Catalan!
+Code in React:
 
-The best practice for i18n is to not attempt to "save bytes" using a 
-substitution parameter. Instead, just translate the multiple strings separately
-in order to get the best translation possible. The memory savings are very small
-anyways.
+```javascript
+    import messages from './messages.js';
 
-If you are substituting in unknown text, for example something that a user has
-entered, you should avoid using definite or indefinite articles with the
-substitution parameter. Instead, you might use a non-grammatical construction
-to avoid the problem of grammar entirely.
+    const messageMap = {
+        "file": messages.delete.file,
+        "folder": messages.delete.folder
+    };
+    const deleteObjString = messageMap[objectToDelete.type];
 
-Bad:
-
-```
-You would like to upload a {item}
+    [...]
+        <MyDialog type="delete">
+            <FormattedMessage {...deleteObjString} />
+        </MyDialog>
 ```
 
-Note that the above doesn't even work in English because "item" may start with a vowel!
+As an engineer, you may think that sharing the string is more efficient, as both strings
+are exactly the same except for the one word, but you are not really saving a lot of
+memory or disk footprint, and instead you are creating an untranslatable string.
 
-Preferred:
+2. If the replacement parameter has an unknown value that is possibly user-entered or
+from a 3rd party library or service, the way you avoid this problem is to make the string
+ungrammatical. That is, you still substitute the value into the string, but you make
+sure that the text being substituted is not grammatically related to the rest of the
+string.
 
+Here is the first example again, but expressed in a non-grammatical way.
+
+```plaintext
+Delete an object with this type: {fileType}
 ```
-Type of item you would like to upload: {item}
+
+Now when you substitute in any word for "fileType", the rest of the string does not need
+to agree with the plurality or gender of the value of "fileType".
+
+## Why does this rule exist?
+
+The reason is that the spelling of the nouns, adjectives, and articles can vary with the
+linguistic case of that part of the sentence as well as the gender and plurality of the
+noun. Even in English, whether you would use "a" or "an" depends on whether the noun
+starts with a vowel, so strings where you substitute a noun might not even work properly
+in English.
+
+Example:
+
+```plaintext
+The {messageType} has been sent.
 ```
 
-In the preferred example, the word substituted in is not grammatically 
-related to the rest of phrase and therefore the string does not need to
-have gender or plurality agreement.
+In this example, "messageType" can have the values "E-mail" and "direct message".
+
+Translated to Polish:
+
+```plaintext
+{messageType} został wysłany.
+```
+
+Unfortunately, the above translation only works for masculine nouns like "E-mail".
+
+```plaintext
+E-mail został wysłany.
+```
+
+But for "direct message", which is female, we would expect to see this in the UI:
+
+```plaintext
+Wiadomość bezpośrednia została wysłana.
+```
+
+Notice that the spelling of the last 2 words is different.
+
+Also, depending on where in the translated sentence the phrase "direct message" is
+placed, the spelling of the value "direct message" itself may change, so you cannot
+just translate "direct message" independently and substitute it into the translated
+string and expect to get the right thing in all target languages.
+
+The reason for this complication is that nouns and other related parts of the sentence
+such as adjectives and articles have to agree in terms of their gender and plurality.
+That is, a masculine noun requires masculine spelling for the article and any adjectives
+that describe it.

--- a/docs/source-no-noun-replacement-params.md
+++ b/docs/source-no-noun-replacement-params.md
@@ -1,0 +1,69 @@
+# source-no-noun-replacement-params
+
+Ensure that source strings do not contain replacement parameters where nouns, noun
+phrases, or adjectives are substituted in to the string. The reason is that the
+spelling of the nouns and adjectives can vary with the linguistic case of that
+part of the sentence. Also, the spelling of the translations of the definite and
+indefinite articles "a", "an", and "the" varies with the gender and plurality of
+the noun or noun phrase being substituted in.
+
+Examples of bad source strings:
+
+```
+Delete the {fileType}.
+Would you like to create a new {fileType} file?
+The {object} has been sent successfully to your company's admin for review.
+```
+
+Very often, the noun, noun phrase or adjective being substituted in has a
+fixed list of possible values. If you are like most engineers, you are probably
+always thinking about how you can write your code to be efficient in terms of memory
+usage, so it seems like it would be better to have one string with a substitution
+rather than two or more separate strings that are almost exactly the same except for
+one word. Only problem is, this optimization messes up translation.
+
+Let's examine the first example above. In that example, the list of possible
+values for the variable fileType is "file" and "folder". That's it. Just two. So
+you might be tempted to use the string above rather than the two strings below:
+
+```
+Delete the file.
+Delete the folder.
+```
+
+The only problem with substituting the noun into that spot is that there is no
+way to translate the word "the" properly to all languages, as well as the words
+"file" and "folder" to fit the linguistic case. In some languages,
+the translation for the word "file" is one gender (either masculine, feminine,
+neutral, or ungendered), whereas the translation for the word "folder" has a
+different gender. And to make matters more complicated, the gender of those
+same two words is different in different languages, even in closely related
+languages such as Spanish, Portuguese, and Catalan!
+
+The best practice for i18n is to not attempt to "save bytes" using a 
+substitution parameter. Instead, just translate the multiple strings separately
+in order to get the best translation possible. The memory savings are very small
+anyways.
+
+If you are substituting in unknown text, for example something that a user has
+entered, you should avoid using definite or indefinite articles with the
+substitution parameter. Instead, you might use a non-grammatical construction
+to avoid the problem of grammar entirely.
+
+Bad:
+
+```
+You would like to upload a {item}
+```
+
+Note that the above doesn't even work in English because "item" may start with a vowel!
+
+Preferred:
+
+```
+Type of item you would like to upload: {item}
+```
+
+In the preferred example, the word substituted in is not grammatically 
+related to the rest of phrase and therefore the string does not need to
+have gender or plurality agreement.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-lint",
-    "version": "1.10.0",
+    "version": "1.11.0",
     "module": "./src/index.js",
     "type": "module",
     "bin": "./src/index.js",

--- a/src/plugins/BuiltinPlugin.js
+++ b/src/plugins/BuiltinPlugin.js
@@ -164,6 +164,16 @@ export const regexRules = [
         regexps: [ "(?<match>\\{[\\w_.$0-9]+\\}\\s*%)(\\s|$)" ],
         link: "https://github.com/ilib-js/i18nlint/blob/main/docs/source-no-manual-percentage-formatting.md",
         severity: "warning"
+    },
+    {
+        type: "resource-source",
+        name: "source-no-noun-replacement-params",
+        description: "Ensure that source strings do not contain replacement parameters that are nouns or adjectives.",
+        note: "Do not substitute nouns into UI strings. Use separate strings for each noun instead.",
+        regexps: [ "(?<match>(a|an|the)\\s+\\{.*?\\})" ],
+        link: "https://github.com/ilib-js/i18nlint/blob/main/docs/source-no-noun-replacement-params.md",
+        severity: "error",
+        useStripped: false
     }
 ];
 
@@ -199,7 +209,8 @@ export const builtInRulesets = {
         "source-no-escaped-curly-braces": true,
         "source-no-dashes-in-replacement-params": true,
         "source-no-lazy-plurals": true,
-        "source-no-manual-percentage-formatting": true
+        "source-no-manual-percentage-formatting": true,
+        "source-no-noun-replacement-params": true
     },
 };
 

--- a/src/plugins/BuiltinPlugin.js
+++ b/src/plugins/BuiltinPlugin.js
@@ -170,7 +170,7 @@ export const regexRules = [
         name: "source-no-noun-replacement-params",
         description: "Ensure that source strings do not contain replacement parameters that are nouns or adjectives.",
         note: "Do not substitute nouns into UI strings. Use separate strings for each noun instead.",
-        regexps: [ "(?<match>(a|an|the)\\s+\\{.*?\\})" ],
+        regexps: [ "\\b(?<match>([Aa][Nn]?|[Tt][Hh][Ee])\\s+\\{.*?\\})" ],
         link: "https://github.com/ilib-js/i18nlint/blob/main/docs/source-no-noun-replacement-params.md",
         severity: "error",
         useStripped: false

--- a/test/testResourceNoNounReplacementParams.js
+++ b/test/testResourceNoNounReplacementParams.js
@@ -1,0 +1,349 @@
+/*
+ * testResourceNoNounReplacementParams.js - test the built-in regular-expression-based rules
+ *
+ * Copyright © 2023 JEDLSoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ResourceString, ResourceArray, ResourcePlural } from 'ilib-tools-common';
+
+import ResourceSourceChecker from '../src/rules/ResourceSourceChecker.js';
+import { regexRules } from '../src/plugins/BuiltinPlugin.js';
+
+import { Result, IntermediateRepresentation } from 'i18nlint-common';
+
+function findRuleDefinition(name) {
+    return regexRules.find(rule => rule.name === name);
+}
+
+export const testResourceNoNounReplacementParams = {
+    testResourceNounParamTheString: function(test) {
+        test.expect(8);
+
+        const rule = new ResourceSourceChecker(findRuleDefinition("source-no-noun-replacement-params"));
+        test.ok(rule);
+
+        const resource = new ResourceString({
+            key: "matcher.test",
+            sourceLocale: "en-US",
+            source: "Delete the {fileType}.",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        test.ok(actual);
+        test.equal(actual.length, 1);
+
+        test.equal(actual[0].severity, "error");
+        test.equal(actual[0].id, "matcher.test");
+        test.equal(actual[0].description, "Do not substitute nouns into UI strings. Use separate strings for each noun instead.");
+        test.equal(actual[0].highlight, "Source: Delete <e0>the {fileType}</e0>.");
+        test.equal(actual[0].pathName, "a/b/c.xliff");
+
+        test.done();
+    },
+
+    testResourceNounParamAString: function(test) {
+        test.expect(8);
+
+        const rule = new ResourceSourceChecker(findRuleDefinition("source-no-noun-replacement-params"));
+        test.ok(rule);
+
+        const resource = new ResourceString({
+            key: "matcher.test",
+            sourceLocale: "en-US",
+            source: "Delete a {fileType}.",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        test.ok(actual);
+        test.equal(actual.length, 1);
+
+        test.equal(actual[0].severity, "error");
+        test.equal(actual[0].id, "matcher.test");
+        test.equal(actual[0].description, "Do not substitute nouns into UI strings. Use separate strings for each noun instead.");
+        test.equal(actual[0].highlight, "Source: Delete <e0>a {fileType}</e0>.");
+        test.equal(actual[0].pathName, "a/b/c.xliff");
+
+        test.done();
+    },
+
+    testResourceNounParamAnString: function(test) {
+        test.expect(8);
+
+        const rule = new ResourceSourceChecker(findRuleDefinition("source-no-noun-replacement-params"));
+        test.ok(rule);
+
+        const resource = new ResourceString({
+            key: "matcher.test",
+            sourceLocale: "en-US",
+            source: "Delete an {fileType}.",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        test.ok(actual);
+        test.equal(actual.length, 1);
+
+        test.equal(actual[0].severity, "error");
+        test.equal(actual[0].id, "matcher.test");
+        test.equal(actual[0].description, "Do not substitute nouns into UI strings. Use separate strings for each noun instead.");
+        test.equal(actual[0].highlight, "Source: Delete <e0>an {fileType}</e0>.");
+        test.equal(actual[0].pathName, "a/b/c.xliff");
+
+        test.done();
+    },
+
+    testResourceNoNounParamString: function(test) {
+        test.expect(2);
+
+        const rule = new ResourceSourceChecker(findRuleDefinition("source-no-noun-replacement-params"));
+        test.ok(rule);
+
+        const resource = new ResourceString({
+            key: "matcher.test",
+            sourceLocale: "en-US",
+            source: "Delete the file.",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        test.ok(!actual);
+
+        test.done();
+    },
+
+    testResourceParamNoArticleString: function(test) {
+        test.expect(2);
+
+        const rule = new ResourceSourceChecker(findRuleDefinition("source-no-noun-replacement-params"));
+        test.ok(rule);
+
+        const resource = new ResourceString({
+            key: "matcher.test",
+            sourceLocale: "en-US",
+            source: "Delete {fileName}.",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        test.ok(!actual);
+
+        test.done();
+    },
+
+    testResourceNoNounParamWithTheElsewhereString: function(test) {
+        test.expect(2);
+
+        const rule = new ResourceSourceChecker(findRuleDefinition("source-no-noun-replacement-params"));
+        test.ok(rule);
+
+        const resource = new ResourceString({
+            key: "matcher.test",
+            sourceLocale: "en-US",
+            source: "Delete the file {fileName}?",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        test.ok(!actual);
+
+        test.done();
+    },
+
+    testResourceNounParamTheMultipleString: function(test) {
+        test.expect(13);
+
+        const rule = new ResourceSourceChecker(findRuleDefinition("source-no-noun-replacement-params"));
+        test.ok(rule);
+
+        const resource = new ResourceString({
+            key: "matcher.test",
+            sourceLocale: "en-US",
+            source: "Delete the {fileType} and the {otherFileType}.",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        test.ok(actual);
+        test.equal(actual.length, 2);
+
+        test.equal(actual[0].severity, "error");
+        test.equal(actual[0].id, "matcher.test");
+        test.equal(actual[0].description, "Do not substitute nouns into UI strings. Use separate strings for each noun instead.");
+        test.equal(actual[0].highlight, "Source: Delete <e0>the {fileType}</e0> and the {otherFileType}.");
+        test.equal(actual[0].pathName, "a/b/c.xliff");
+
+        test.equal(actual[1].severity, "error");
+        test.equal(actual[1].id, "matcher.test");
+        test.equal(actual[1].description, "Do not substitute nouns into UI strings. Use separate strings for each noun instead.");
+        test.equal(actual[1].highlight, "Source: Delete the {fileType} and <e0>the {otherFileType}</e0>.");
+        test.equal(actual[1].pathName, "a/b/c.xliff");
+
+        test.done();
+    },
+
+    testResourceNounParamThePluralString: function(test) {
+        test.expect(13);
+
+        const rule = new ResourceSourceChecker(findRuleDefinition("source-no-noun-replacement-params"));
+        test.ok(rule);
+
+        const resource = new ResourceString({
+            key: "matcher.test",
+            sourceLocale: "en-US",
+            source: "{count, plural, one {Delete the {fileType}.} other {Delete the {fileTypePlural}.}}",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        test.ok(actual);
+        test.equal(actual.length, 2);
+
+        test.equal(actual[0].severity, "error");
+        test.equal(actual[0].id, "matcher.test");
+        test.equal(actual[0].description, "Do not substitute nouns into UI strings. Use separate strings for each noun instead.");
+        test.equal(actual[0].highlight, "Source: {count, plural, one {Delete <e0>the {fileType}</e0>.} other {Delete the {fileTypePlural}.}}");
+        test.equal(actual[0].pathName, "a/b/c.xliff");
+
+        test.equal(actual[1].severity, "error");
+        test.equal(actual[1].id, "matcher.test");
+        test.equal(actual[1].description, "Do not substitute nouns into UI strings. Use separate strings for each noun instead.");
+        test.equal(actual[1].highlight, "Source: {count, plural, one {Delete the {fileType}.} other {Delete <e0>the {fileTypePlural}</e0>.}}");
+        test.equal(actual[1].pathName, "a/b/c.xliff");
+
+        test.done();
+    },
+
+    testResourceNounParamThePlural: function(test) {
+        test.expect(13);
+
+        const rule = new ResourceSourceChecker(findRuleDefinition("source-no-noun-replacement-params"));
+        test.ok(rule);
+
+        const resource = new ResourcePlural({
+            key: "matcher.test",
+            sourceLocale: "en-US",
+            source: {
+                one: "Delete the {fileType}.",
+                other: "Delete the {fileTypes}."
+            },
+            pathName: "a/b/c.xliff"
+        });
+        const ir = new IntermediateRepresentation({
+            type: "resource",
+            ir: [resource],
+            filePath: "a/b/c.xliff"
+        });
+
+        const actual = rule.match({
+            file: "a/b/c.xliff",
+            ir
+        });
+
+        test.ok(actual);
+        test.equal(actual.length, 2);
+
+        test.equal(actual[0].severity, "error");
+        test.equal(actual[0].id, "matcher.test");
+        test.equal(actual[0].description, "Do not substitute nouns into UI strings. Use separate strings for each noun instead.");
+        test.equal(actual[0].highlight, "Source: Delete <e0>the {fileType}</e0>.");
+        test.equal(actual[0].pathName, "a/b/c.xliff");
+
+        test.equal(actual[1].severity, "error");
+        test.equal(actual[1].id, "matcher.test");
+        test.equal(actual[1].description, "Do not substitute nouns into UI strings. Use separate strings for each noun instead.");
+        test.equal(actual[1].highlight, "Source: Delete <e0>the {fileTypes}</e0>.");
+        test.equal(actual[1].pathName, "a/b/c.xliff");
+
+        test.done();
+    },
+
+    testResourceNounParamTheArray: function(test) {
+        test.expect(13);
+
+        const rule = new ResourceSourceChecker(findRuleDefinition("source-no-noun-replacement-params"));
+        test.ok(rule);
+
+        const resource = new ResourceArray({
+            key: "matcher.test",
+            sourceLocale: "en-US",
+            source: [
+                "Delete the {fileType}.",
+                "Delete the {fileTypes}."
+            ],
+            pathName: "a/b/c.xliff"
+        });
+        const ir = new IntermediateRepresentation({
+            type: "resource",
+            ir: [resource],
+            filePath: "a/b/c.xliff"
+        });
+
+        const actual = rule.match({
+            file: "a/b/c.xliff",
+            ir
+        });
+
+        test.ok(actual);
+        test.equal(actual.length, 2);
+
+        test.equal(actual[0].severity, "error");
+        test.equal(actual[0].id, "matcher.test");
+        test.equal(actual[0].description, "Do not substitute nouns into UI strings. Use separate strings for each noun instead.");
+        test.equal(actual[0].highlight, "Source: Delete <e0>the {fileType}</e0>.");
+        test.equal(actual[0].pathName, "a/b/c.xliff");
+
+        test.equal(actual[1].severity, "error");
+        test.equal(actual[1].id, "matcher.test");
+        test.equal(actual[1].description, "Do not substitute nouns into UI strings. Use separate strings for each noun instead.");
+        test.equal(actual[1].highlight, "Source: Delete <e0>the {fileTypes}</e0>.");
+        test.equal(actual[1].pathName, "a/b/c.xliff");
+
+        test.done();
+    },
+};

--- a/test/testResourceNoNounReplacementParams.js
+++ b/test/testResourceNoNounReplacementParams.js
@@ -346,4 +346,131 @@ export const testResourceNoNounReplacementParams = {
 
         test.done();
     },
+
+    testResourceNounParamTheCapitalsString: function(test) {
+        test.expect(18);
+
+        const rule = new ResourceSourceChecker(findRuleDefinition("source-no-noun-replacement-params"));
+        test.ok(rule);
+
+        const resource = new ResourceString({
+            key: "matcher.test",
+            sourceLocale: "en-US",
+            source: "Delete The {fileType} And A {fileType} and An {fileType}.",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        test.ok(actual);
+        test.equal(actual.length, 3);
+
+        test.equal(actual[0].severity, "error");
+        test.equal(actual[0].id, "matcher.test");
+        test.equal(actual[0].description, "Do not substitute nouns into UI strings. Use separate strings for each noun instead.");
+        test.equal(actual[0].highlight, "Source: Delete <e0>The {fileType}</e0> And A {fileType} and An {fileType}.");
+        test.equal(actual[0].pathName, "a/b/c.xliff");
+
+        test.equal(actual[1].severity, "error");
+        test.equal(actual[1].id, "matcher.test");
+        test.equal(actual[1].description, "Do not substitute nouns into UI strings. Use separate strings for each noun instead.");
+        test.equal(actual[1].highlight, "Source: Delete The {fileType} And <e0>A {fileType}</e0> and An {fileType}.");
+        test.equal(actual[1].pathName, "a/b/c.xliff");
+
+        test.equal(actual[2].severity, "error");
+        test.equal(actual[2].id, "matcher.test");
+        test.equal(actual[2].description, "Do not substitute nouns into UI strings. Use separate strings for each noun instead.");
+        test.equal(actual[2].highlight, "Source: Delete The {fileType} And A {fileType} and <e0>An {fileType}</e0>.");
+        test.equal(actual[2].pathName, "a/b/c.xliff");
+
+        test.done();
+    },
+
+    testResourceNounParamNotWholeWordString: function(test) {
+        test.expect(2);
+
+        const rule = new ResourceSourceChecker(findRuleDefinition("source-no-noun-replacement-params"));
+        test.ok(rule);
+
+        // should not match "a" and "the" when it is not a separate word
+        const resource = new ResourceString({
+            key: "matcher.test",
+            sourceLocale: "en-US",
+            source: "Paula {verb} loathe {cucumber}.",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        test.ok(!actual);
+
+        test.done();
+    },
+
+    testResourceNounParamTheStartOfString: function(test) {
+        test.expect(8);
+
+        const rule = new ResourceSourceChecker(findRuleDefinition("source-no-noun-replacement-params"));
+        test.ok(rule);
+
+        const resource = new ResourceString({
+            key: "matcher.test",
+            sourceLocale: "en-US",
+            source: "The {fileType} to delete.",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        test.ok(actual);
+        test.equal(actual.length, 1);
+
+        test.equal(actual[0].severity, "error");
+        test.equal(actual[0].id, "matcher.test");
+        test.equal(actual[0].description, "Do not substitute nouns into UI strings. Use separate strings for each noun instead.");
+        test.equal(actual[0].highlight, "Source: <e0>The {fileType}</e0> to delete.");
+        test.equal(actual[0].pathName, "a/b/c.xliff");
+
+        test.done();
+    },
+
+    testResourceNounParamTheEndOfString: function(test) {
+        test.expect(8);
+
+        const rule = new ResourceSourceChecker(findRuleDefinition("source-no-noun-replacement-params"));
+        test.ok(rule);
+
+        const resource = new ResourceString({
+            key: "matcher.test",
+            sourceLocale: "en-US",
+            source: "Delete the {fileType}",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        test.ok(actual);
+        test.equal(actual.length, 1);
+
+        test.equal(actual[0].severity, "error");
+        test.equal(actual[0].id, "matcher.test");
+        test.equal(actual[0].description, "Do not substitute nouns into UI strings. Use separate strings for each noun instead.");
+        test.equal(actual[0].highlight, "Source: Delete <e0>the {fileType}</e0>");
+        test.equal(actual[0].pathName, "a/b/c.xliff");
+
+        test.done();
+    },
+
 };

--- a/test/testSuiteFiles.js
+++ b/test/testSuiteFiles.js
@@ -32,6 +32,7 @@ const files = [
     "testResourceNoEscapedCurlyBraces.js",
     "testResourceNoLazyPlurals.js",
     "testResourceNoManualPercentFormatting.js",
+    "testResourceNoNounReplacementParams.js",
     "testResourceNoTranslation.js",
     "testResourceQuoteStyle.js",
     "testResourceSourceICUPluralSyntax.js",


### PR DESCRIPTION
- if you use an article "a", "an", or "the" in front of a replacement parameter, this rule will give an error result because the article is untranslatable