### PR TITLE
Add rule to check for manually formatted currency

### DIFF
--- a/README.md
+++ b/README.md
@@ -725,7 +725,7 @@ limitations under the License.
   because of gender and plurality agreement rules.
 - converted all unit tests from  nodeunit to jest
 - updated dependencies
-- added source-no-manual-currency-formatting ri;e to check that source strings
+- added source-no-manual-currency-formatting rule to check that source strings
   do not contain manually formatted currencies. Tell the engineer to use a
   locale-sensitive number formatter instead.
 

--- a/README.md
+++ b/README.md
@@ -725,6 +725,9 @@ limitations under the License.
   because of gender and plurality agreement rules.
 - converted all unit tests from  nodeunit to jest
 - updated dependencies
+- added source-no-manual-currency-formatting ri;e to check that source strings
+  do not contain manually formatted currencies. Tell the engineer to use a
+  locale-sensitive number formatter instead.
 
 ### v1.10.0
 

--- a/docs/source-no-manual-currency-formatting.md
+++ b/docs/source-no-manual-currency-formatting.md
@@ -1,0 +1,43 @@
+# source-no-manual-currency-formatting
+
+Ensure that source strings do not contain manually formatted currencies.
+Currencies should be formatted with a locale-sensitive number formatter,
+such as the `FormattedNumber` component in react-intl, and the result
+should be substituted into the current string. Most number formatters can
+format basic numbers, percentages, or a currency amounts and there is
+usually a "style" parameter that selects which one of those the caller needs.
+
+Bad source string:
+
+```
+${cost} per month.
+```
+
+Preferred source string:
+
+```
+{cost} per month.
+```
+
+Where the cost is formatted by a number formatter and the result
+substituted into the string.
+
+Example in React with react-intl:
+
+```js
+const messages = defineMessages({
+    monthlySubscriptionFee: {
+        id: "unique.id",
+        description: "Tells the user how much the monthly fee is for our service.",
+        defaultMessage: "{cost} per month"
+    }
+});
+
+<FormattedMessage ...messages.monthlySubscriptionFee values={{
+    cost: <FormattedNumber
+        value={this.fees.monthly}
+        currency={this.user.preferredCurrency}
+        style="currency"
+    />
+}}/>
+```

--- a/src/plugins/BuiltinPlugin.js
+++ b/src/plugins/BuiltinPlugin.js
@@ -174,6 +174,15 @@ export const regexRules = [
         link: "https://github.com/ilib-js/i18nlint/blob/main/docs/source-no-noun-replacement-params.md",
         severity: "error",
         useStripped: false
+    },
+    {
+        type: "resource-source",
+        name: "source-no-manual-currency-formatting",
+        description: "Ensure that source strings do not contain currency formatting. Currencies should be formatted using a locale-sensitive number formatter instead.",
+        note: "Do not format currencies in English strings. Use a locale-sensitive number formatter and substitute the result of that into this string.",
+        regexps: [ "(?<match>\\$\\s*\\{[\\w_.$0-9]+\\})" ],
+        link: "https://github.com/ilib-js/i18nlint/blob/main/docs/source-no-manual-currency-formatting.md",
+        severity: "error"
     }
 ];
 
@@ -210,7 +219,8 @@ export const builtInRulesets = {
         "source-no-dashes-in-replacement-params": true,
         "source-no-lazy-plurals": true,
         "source-no-manual-percentage-formatting": true,
-        "source-no-noun-replacement-params": true
+        "source-no-noun-replacement-params": true,
+        "source-no-manual-currency-formatting": true
     },
 };
 

--- a/test/ResourceNoManualCurrencyFormatting.test.js
+++ b/test/ResourceNoManualCurrencyFormatting.test.js
@@ -1,0 +1,275 @@
+/*
+ * ResourceNoManualPercentFormatting.test.js - test the built-in regular-expression-based rules
+ *
+ * Copyright © 2023 JEDLSoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ResourceString, ResourceArray, ResourcePlural } from 'ilib-tools-common';
+
+import ResourceSourceChecker from '../src/rules/ResourceSourceChecker.js';
+import { regexRules } from '../src/plugins/BuiltinPlugin.js';
+
+import { Result, IntermediateRepresentation } from 'i18nlint-common';
+
+function findRuleDefinition(name) {
+    return regexRules.find(rule => rule.name === name);
+}
+
+describe("testResourceNoManualPercentageFormatting", () => {
+    test("ResourceManualPercentFormatting", () => {
+        expect.assertions(8);
+
+        const rule = new ResourceSourceChecker(findRuleDefinition("source-no-manual-currency-formatting"));
+        expect(rule).toBeTruthy();
+
+        const resource = new ResourceString({
+            key: "matcher.test",
+            sourceLocale: "en-US",
+            source: "It costs ${num}.",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        expect(actual).toBeTruthy();
+        expect(actual.length).toBe(1);
+
+        expect(actual[0].severity).toBe("error");
+        expect(actual[0].id).toBe("matcher.test");
+        expect(actual[0].description).toBe("Do not format currencies in English strings. Use a locale-sensitive number formatter and substitute the result of that into this string.");
+        expect(actual[0].highlight).toBe("Source: It costs <e0>${num}</e0>.");
+        expect(actual[0].pathName).toBe("a/b/c.xliff");
+    });
+
+    test("ResourceNoManualPercentFormatting", () => {
+        expect.assertions(2);
+
+        const rule = new ResourceSourceChecker(findRuleDefinition("source-no-manual-currency-formatting"));
+        expect(rule).toBeTruthy();
+
+        const resource = new ResourceString({
+            key: "matcher.test",
+            sourceLocale: "en-US",
+            source: "It costs {num}.",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        expect(!actual).toBeTruthy();
+    });
+
+    test("ResourceManualPercentFormattingWithWhitespace", () => {
+        expect.assertions(8);
+
+        const rule = new ResourceSourceChecker(findRuleDefinition("source-no-manual-currency-formatting"));
+        expect(rule).toBeTruthy();
+
+        const resource = new ResourceString({
+            key: "matcher.test",
+            sourceLocale: "en-US",
+            source: "It costs $ {num}.",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        expect(actual).toBeTruthy();
+        expect(actual.length).toBe(1);
+
+        expect(actual[0].severity).toBe("error");
+        expect(actual[0].id).toBe("matcher.test");
+        expect(actual[0].description).toBe("Do not format currencies in English strings. Use a locale-sensitive number formatter and substitute the result of that into this string.");
+        expect(actual[0].highlight).toBe("Source: It costs <e0>$ {num}</e0>.");
+        expect(actual[0].pathName).toBe("a/b/c.xliff");
+    });
+
+    test("ResourceManualPercentFormattingCrazyParamName", () => {
+        expect.assertions(8);
+
+        const rule = new ResourceSourceChecker(findRuleDefinition("source-no-manual-currency-formatting"));
+        expect(rule).toBeTruthy();
+
+        const resource = new ResourceString({
+            key: "matcher.test",
+            sourceLocale: "en-US",
+            source: "It costs ${numCapital_$foo.bar}.",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        expect(actual).toBeTruthy();
+        expect(actual.length).toBe(1);
+
+        expect(actual[0].severity).toBe("error");
+        expect(actual[0].id).toBe("matcher.test");
+        expect(actual[0].description).toBe("Do not format currencies in English strings. Use a locale-sensitive number formatter and substitute the result of that into this string.");
+        expect(actual[0].highlight).toBe("Source: It costs <e0>${numCapital_$foo.bar}</e0>.");
+        expect(actual[0].pathName).toBe("a/b/c.xliff");
+    });
+
+    test("ResourceManualPercentFormattingStartOfString", () => {
+        expect.assertions(8);
+
+        const rule = new ResourceSourceChecker(findRuleDefinition("source-no-manual-currency-formatting"));
+        expect(rule).toBeTruthy();
+
+        const resource = new ResourceString({
+            key: "matcher.test",
+            sourceLocale: "en-US",
+            source: "${num} per month",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        expect(actual).toBeTruthy();
+        expect(actual.length).toBe(1);
+
+        expect(actual[0].severity).toBe("error");
+        expect(actual[0].id).toBe("matcher.test");
+        expect(actual[0].description).toBe("Do not format currencies in English strings. Use a locale-sensitive number formatter and substitute the result of that into this string.");
+        expect(actual[0].highlight).toBe("Source: <e0>${num}</e0> per month");
+        expect(actual[0].pathName).toBe("a/b/c.xliff");
+    });
+
+    test("ResourceManualPercentFormattingStartOfString", () => {
+        expect.assertions(8);
+
+        const rule = new ResourceSourceChecker(findRuleDefinition("source-no-manual-currency-formatting"));
+        expect(rule).toBeTruthy();
+
+        const resource = new ResourceString({
+            key: "matcher.test",
+            sourceLocale: "en-US",
+            source: "Cost is ${num}",
+            pathName: "a/b/c.xliff"
+        });
+        const actual = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        expect(actual).toBeTruthy();
+        expect(actual.length).toBe(1);
+
+        expect(actual[0].severity).toBe("error");
+        expect(actual[0].id).toBe("matcher.test");
+        expect(actual[0].description).toBe("Do not format currencies in English strings. Use a locale-sensitive number formatter and substitute the result of that into this string.");
+        expect(actual[0].highlight).toBe("Source: Cost is <e0>${num}</e0>");
+        expect(actual[0].pathName).toBe("a/b/c.xliff");
+    });
+
+    test("ResourceNounParamThePlural", () => {
+        expect.assertions(13);
+
+        const rule = new ResourceSourceChecker(findRuleDefinition("source-no-manual-currency-formatting"));
+        expect(rule).toBeTruthy();
+
+        const resource = new ResourcePlural({
+            key: "matcher.test",
+            sourceLocale: "en-US",
+            source: {
+                one: "Cost is ${cost}.",
+                other: "Costs are ${cost}."
+            },
+            pathName: "a/b/c.xliff"
+        });
+        const ir = new IntermediateRepresentation({
+            type: "resource",
+            ir: [resource],
+            filePath: "a/b/c.xliff"
+        });
+
+        const actual = rule.match({
+            file: "a/b/c.xliff",
+            ir
+        });
+
+        expect(actual).toBeTruthy();
+        expect(actual.length).toBe(2);
+
+        expect(actual[0].severity).toBe("error");
+        expect(actual[0].id).toBe("matcher.test");
+        expect(actual[0].description).toBe("Do not format currencies in English strings. Use a locale-sensitive number formatter and substitute the result of that into this string.");
+        expect(actual[0].highlight).toBe("Source: Cost is <e0>${cost}</e0>.");
+        expect(actual[0].pathName).toBe("a/b/c.xliff");
+
+        expect(actual[1].severity).toBe("error");
+        expect(actual[1].id).toBe("matcher.test");
+        expect(actual[1].description).toBe("Do not format currencies in English strings. Use a locale-sensitive number formatter and substitute the result of that into this string.");
+        expect(actual[1].highlight).toBe("Source: Costs are <e0>${cost}</e0>.");
+        expect(actual[1].pathName).toBe("a/b/c.xliff");
+    });
+
+    test("ResourceNounParamTheArray", () => {
+        expect.assertions(13);
+
+        const rule = new ResourceSourceChecker(findRuleDefinition("source-no-manual-currency-formatting"));
+        expect(rule).toBeTruthy();
+
+        const resource = new ResourceArray({
+            key: "matcher.test",
+            sourceLocale: "en-US",
+            source: [
+                "Cost is ${cost}.",
+                "Costs are ${cost}."
+            ],
+            pathName: "a/b/c.xliff"
+        });
+        const ir = new IntermediateRepresentation({
+            type: "resource",
+            ir: [resource],
+            filePath: "a/b/c.xliff"
+        });
+
+        const actual = rule.match({
+            file: "a/b/c.xliff",
+            ir
+        });
+
+        expect(actual).toBeTruthy();
+        expect(actual.length).toBe(2);
+
+        expect(actual[0].severity).toBe("error");
+        expect(actual[0].id).toBe("matcher.test");
+        expect(actual[0].description).toBe("Do not format currencies in English strings. Use a locale-sensitive number formatter and substitute the result of that into this string.");
+        expect(actual[0].highlight).toBe("Source: Cost is <e0>${cost}</e0>.");
+        expect(actual[0].pathName).toBe("a/b/c.xliff");
+
+        expect(actual[1].severity).toBe("error");
+        expect(actual[1].id).toBe("matcher.test");
+        expect(actual[1].description).toBe("Do not format currencies in English strings. Use a locale-sensitive number formatter and substitute the result of that into this string.");
+        expect(actual[1].highlight).toBe("Source: Costs are <e0>${cost}</e0>.");
+        expect(actual[1].pathName).toBe("a/b/c.xliff");
+    });
+});

--- a/test/ResourceNoManualCurrencyFormatting.test.js
+++ b/test/ResourceNoManualCurrencyFormatting.test.js
@@ -189,7 +189,7 @@ describe("testResourceNoManualCurrencyFormatting", () => {
         expect(actual[0].pathName).toBe("a/b/c.xliff");
     });
 
-    test("ResourceNounParamThePlural", () => {
+    test("ResourceManualCurrencyFormattingPlural", () => {
         expect.assertions(13);
 
         const rule = new ResourceSourceChecker(findRuleDefinition("source-no-manual-currency-formatting"));
@@ -231,7 +231,7 @@ describe("testResourceNoManualCurrencyFormatting", () => {
         expect(actual[1].pathName).toBe("a/b/c.xliff");
     });
 
-    test("ResourceNounParamTheArray", () => {
+    test("ResourceManualCurrencyFormattingArray", () => {
         expect.assertions(13);
 
         const rule = new ResourceSourceChecker(findRuleDefinition("source-no-manual-currency-formatting"));

--- a/test/ResourceNoManualCurrencyFormatting.test.js
+++ b/test/ResourceNoManualCurrencyFormatting.test.js
@@ -161,7 +161,7 @@ describe("testResourceNoManualPercentageFormatting", () => {
         expect(actual[0].pathName).toBe("a/b/c.xliff");
     });
 
-    test("ResourceManualPercentFormattingStartOfString", () => {
+    test("ResourceManualPercentFormattingEndOfString", () => {
         expect.assertions(8);
 
         const rule = new ResourceSourceChecker(findRuleDefinition("source-no-manual-currency-formatting"));

--- a/test/ResourceNoManualCurrencyFormatting.test.js
+++ b/test/ResourceNoManualCurrencyFormatting.test.js
@@ -27,8 +27,8 @@ function findRuleDefinition(name) {
     return regexRules.find(rule => rule.name === name);
 }
 
-describe("testResourceNoManualCurrencyFormatting", () => {
-    test("ResourceManualCurrencyFormatting", () => {
+describe("make sure that Resources have No Manual Currency Formatting Allowed", () => {
+    test("Resource Has Manual Currency Formatting", () => {
         expect.assertions(8);
 
         const rule = new ResourceSourceChecker(findRuleDefinition("source-no-manual-currency-formatting"));
@@ -56,7 +56,7 @@ describe("testResourceNoManualCurrencyFormatting", () => {
         expect(actual[0].pathName).toBe("a/b/c.xliff");
     });
 
-    test("ResourceNoManualCurrencyFormatting", () => {
+    test("Resource Has No Manual Currency Formatting", () => {
         expect.assertions(2);
 
         const rule = new ResourceSourceChecker(findRuleDefinition("source-no-manual-currency-formatting"));
@@ -77,7 +77,7 @@ describe("testResourceNoManualCurrencyFormatting", () => {
         expect(!actual).toBeTruthy();
     });
 
-    test("ResourceManualCurrencyFormattingWithWhitespace", () => {
+    test("Resource Has Manual Currency Formatting With Whitespace", () => {
         expect.assertions(8);
 
         const rule = new ResourceSourceChecker(findRuleDefinition("source-no-manual-currency-formatting"));
@@ -105,7 +105,7 @@ describe("testResourceNoManualCurrencyFormatting", () => {
         expect(actual[0].pathName).toBe("a/b/c.xliff");
     });
 
-    test("ResourceManualCurrencyFormattingCrazyParamName", () => {
+    test("Resource Has Manual Currency Formatting and a Crazy Param Name", () => {
         expect.assertions(8);
 
         const rule = new ResourceSourceChecker(findRuleDefinition("source-no-manual-currency-formatting"));
@@ -133,7 +133,7 @@ describe("testResourceNoManualCurrencyFormatting", () => {
         expect(actual[0].pathName).toBe("a/b/c.xliff");
     });
 
-    test("ResourceManualCurrencyFormattingStartOfString", () => {
+    test("Resource Has Manual Currency Formatting at the Start Of the String", () => {
         expect.assertions(8);
 
         const rule = new ResourceSourceChecker(findRuleDefinition("source-no-manual-currency-formatting"));
@@ -161,7 +161,7 @@ describe("testResourceNoManualCurrencyFormatting", () => {
         expect(actual[0].pathName).toBe("a/b/c.xliff");
     });
 
-    test("ResourceManualCurrencyFormattingEndOfString", () => {
+    test("Resource Has Manual Currency Formatting at the End Of the String", () => {
         expect.assertions(8);
 
         const rule = new ResourceSourceChecker(findRuleDefinition("source-no-manual-currency-formatting"));
@@ -189,7 +189,7 @@ describe("testResourceNoManualCurrencyFormatting", () => {
         expect(actual[0].pathName).toBe("a/b/c.xliff");
     });
 
-    test("ResourceManualCurrencyFormattingPlural", () => {
+    test("Plural Resource Has Manual Currency Formatting", () => {
         expect.assertions(13);
 
         const rule = new ResourceSourceChecker(findRuleDefinition("source-no-manual-currency-formatting"));
@@ -231,7 +231,7 @@ describe("testResourceNoManualCurrencyFormatting", () => {
         expect(actual[1].pathName).toBe("a/b/c.xliff");
     });
 
-    test("ResourceManualCurrencyFormattingArray", () => {
+    test("Array Resource Has Manual Currency Formatting", () => {
         expect.assertions(13);
 
         const rule = new ResourceSourceChecker(findRuleDefinition("source-no-manual-currency-formatting"));

--- a/test/ResourceNoManualCurrencyFormatting.test.js
+++ b/test/ResourceNoManualCurrencyFormatting.test.js
@@ -1,5 +1,5 @@
 /*
- * ResourceNoManualPercentFormatting.test.js - test the built-in regular-expression-based rules
+ * ResourceNoManualCurrencyFormatting.test.js - test the built-in regular-expression-based rules
  *
  * Copyright © 2023 JEDLSoft
  *
@@ -27,8 +27,8 @@ function findRuleDefinition(name) {
     return regexRules.find(rule => rule.name === name);
 }
 
-describe("testResourceNoManualPercentageFormatting", () => {
-    test("ResourceManualPercentFormatting", () => {
+describe("testResourceNoManualCurrencyFormatting", () => {
+    test("ResourceManualCurrencyFormatting", () => {
         expect.assertions(8);
 
         const rule = new ResourceSourceChecker(findRuleDefinition("source-no-manual-currency-formatting"));
@@ -56,7 +56,7 @@ describe("testResourceNoManualPercentageFormatting", () => {
         expect(actual[0].pathName).toBe("a/b/c.xliff");
     });
 
-    test("ResourceNoManualPercentFormatting", () => {
+    test("ResourceNoManualCurrencyFormatting", () => {
         expect.assertions(2);
 
         const rule = new ResourceSourceChecker(findRuleDefinition("source-no-manual-currency-formatting"));
@@ -77,7 +77,7 @@ describe("testResourceNoManualPercentageFormatting", () => {
         expect(!actual).toBeTruthy();
     });
 
-    test("ResourceManualPercentFormattingWithWhitespace", () => {
+    test("ResourceManualCurrencyFormattingWithWhitespace", () => {
         expect.assertions(8);
 
         const rule = new ResourceSourceChecker(findRuleDefinition("source-no-manual-currency-formatting"));
@@ -105,7 +105,7 @@ describe("testResourceNoManualPercentageFormatting", () => {
         expect(actual[0].pathName).toBe("a/b/c.xliff");
     });
 
-    test("ResourceManualPercentFormattingCrazyParamName", () => {
+    test("ResourceManualCurrencyFormattingCrazyParamName", () => {
         expect.assertions(8);
 
         const rule = new ResourceSourceChecker(findRuleDefinition("source-no-manual-currency-formatting"));
@@ -133,7 +133,7 @@ describe("testResourceNoManualPercentageFormatting", () => {
         expect(actual[0].pathName).toBe("a/b/c.xliff");
     });
 
-    test("ResourceManualPercentFormattingStartOfString", () => {
+    test("ResourceManualCurrencyFormattingStartOfString", () => {
         expect.assertions(8);
 
         const rule = new ResourceSourceChecker(findRuleDefinition("source-no-manual-currency-formatting"));
@@ -161,7 +161,7 @@ describe("testResourceNoManualPercentageFormatting", () => {
         expect(actual[0].pathName).toBe("a/b/c.xliff");
     });
 
-    test("ResourceManualPercentFormattingEndOfString", () => {
+    test("ResourceManualCurrencyFormattingEndOfString", () => {
         expect.assertions(8);
 
         const rule = new ResourceSourceChecker(findRuleDefinition("source-no-manual-currency-formatting"));


### PR DESCRIPTION
- currencies should be formatted with a locale-sensitive number formatter and given the currency code to use