### PR TITLE
Fix space rule to accept punctuation

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,6 +529,9 @@ limitations under the License.
 
 - make sure the results are sorted by file path and also line number within
   that file path
+- updated the rule that checks for spaces between double- and single-byte
+  characters. The rule now allows for spaces between double-byte characters
+  and single-byte punctuation.
 
 ### v1.12.0
 

--- a/docs/resource-no-space-between-double-and-single-byte-character.md
+++ b/docs/resource-no-space-between-double-and-single-byte-character.md
@@ -1,12 +1,16 @@
 # resource-no-space-between-double-and-single-byte-character
 
-Ensure that translations do not contain a space character between a double-byte and single-byte character.",
+Ensure that translations do not contain a space character between a double-byte and single-byte character.
+Punctuation characters are not included, so a space may appear between the double-byte character and
+the single-byte punctuation.
 
 Examples:
 
-Good translation: "Box埋め込みウィジェット"
-Bad translation: "Box 埋め込みウィジェット"
+Good: "Box埋め込みウィジェット"<br>
+Bad: "Box 埋め込みウィジェット"
 
-Good translation: "EXIFおよびXMPメタデータ"
-Bad translation: "EXIF および XMP メタデータ"
-Bad translation: "EXIFおよび XMPメタデータ"
+Good: "EXIFおよびXMPメタデータ"<br>
+Bad: "EXIF および XMP メタデータ"<br>
+Bad: "EXIFおよび XMPメタデータ"
+
+Good: "[EXIF] および [XMP] メタデータ" (Okay to have space between double-byte character and single-byte punctuation)

--- a/src/plugins/BuiltinPlugin.js
+++ b/src/plugins/BuiltinPlugin.js
@@ -83,8 +83,8 @@ export const regexRules = [
         type: "resource-target",
         name: "resource-no-space-between-double-and-single-byte-character",
         description: "Ensure that the target does not contain a space character between a double-byte and single-byte character.",
-        note: "The space character is not allowed in the target string. Remove the space character.",
-        regexps: [ "[\\u3040-\\u309F\\u30A0-\\u30FF\\u4E00-\\u9FAF]\\s+[\\x00-\\xFF]|[\\x00-\\xFF]\\s+[\\u3040-\\u309F\\u30A0-\\u30FF\\u4E00-\\u9FAF]" ],
+        note: "The space character is not allowed in the target string between a double- and single-byte character. Remove the space character.",
+        regexps: [ "[\\u3040-\\u309F\\u30A0-\\u30FF\\u4E00-\\u9FAF]\\s+[\\x00-\\x20\\x30-\\x39\\x41-\\x5A\\x61-\\x7A\\x8A\\x8C\\x8E\\x9A\\x9C\\x9E\\x9F\\xC0-\\xD6\\xD8-\\xF6\\xF8-\\xFF]|[\\x00-\\x20\\x30-\\x39\\x41-\\x5A\\x61-\\x7A\\x8A\\x8C\\x8E\\x9A\\x9C\\x9E\\x9F\\xC0-\\xD6\\xD8-\\xF6\\xF8-\\xFF]\\s+[\\u3040-\\u309F\\u30A0-\\u30FF\\u4E00-\\u9FAF]" ],
         link: "https://github.com/ilib-js/i18nlint/blob/main/docs/resource-no-space-between-double-and-single-byte-character.md",
         severity: "warning",
         locales: "ja"

--- a/test/ResourceTargetChecker.test.js
+++ b/test/ResourceTargetChecker.test.js
@@ -809,7 +809,7 @@ describe("testResourceTargetChecker", () => {
             sourceLocale: "en-US",
             source: "Box Embed Widget",
             targetLocale: "ja-JP",
-            target: "[EXIF] および [XMP] メタデータ",
+            target: "[EXIF] および (XMP) メタデータ",
             pathName: "a/b/c.xliff",
         });
 

--- a/test/ResourceTargetChecker.test.js
+++ b/test/ResourceTargetChecker.test.js
@@ -793,9 +793,33 @@ describe("testResourceTargetChecker", () => {
             pathName: "a/b/c.xliff",
             source: "Box Embed Widget",
             id: "matcher.test",
-            description: 'The space character is not allowed in the target string. Remove the space character.',
+            description: 'The space character is not allowed in the target string between a double- and single-byte character. Remove the space character.',
             highlight: 'Target: Bo<e0>x 埋</e0>め込みウィジェット',
         })]);
+    });
+
+    test("No Space Between Double And Single Byte Character, but not counting punctuation", () => {
+        expect.assertions(2);
+
+        const rule = new ResourceTargetChecker(findRuleDefinition("resource-no-space-between-double-and-single-byte-character"));
+        expect(rule).toBeTruthy();
+
+        const resource = new ResourceString({
+            key: "matcher.test",
+            sourceLocale: "en-US",
+            source: "Box Embed Widget",
+            targetLocale: "ja-JP",
+            target: "[EXIF] および [XMP] メタデータ",
+            pathName: "a/b/c.xliff",
+        });
+
+        const result = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        expect(result).toBeFalsy();
     });
 
     test("ResourceNoSpaceBetweenDoubleAndSingleByteCharacterNotInChinese", () => {

--- a/test/ResourceTargetChecker.test.js
+++ b/test/ResourceTargetChecker.test.js
@@ -846,6 +846,30 @@ describe("testResourceTargetChecker", () => {
         expect(!result).toBeTruthy();
     });
 
+    test("No Space Between Double And Single Byte Character Not In Chinese, including with punctuation", () => {
+        expect.assertions(2);
+
+        const rule = new ResourceTargetChecker(findRuleDefinition("resource-no-space-between-double-and-single-byte-character"));
+        expect(rule).toBeTruthy();
+
+        const resource = new ResourceString({
+            key: "matcher.test",
+            sourceLocale: "en-US",
+            source: "Box Embed Widget",
+            targetLocale: "zh-Hans-CN",
+            target: "[EXIF] および (XMP) メタデータ",
+            pathName: "a/b/c.xliff",
+        });
+
+        const result = rule.matchString({
+            source: resource.getSource(),
+            target: resource.getTarget(),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        expect(result).toBeFalsy();
+    });
+
     test("ResourceNoSpaceBetweenDoubleAndSingleByteCharacterSuccess", () => {
         expect.assertions(2);
 


### PR DESCRIPTION
- fix the rule for Japanese that checks for no spaces between double- and single-byte character to allow a space between double-byte characters and single-byte punctuation characters