### PR TITLE
Disable Italian quote style checking

### DIFF
--- a/src/rules/ResourceQuoteStyle.js
+++ b/src/rules/ResourceQuoteStyle.js
@@ -57,8 +57,8 @@ class ResourceQuoteStyle extends ResourceRule {
         }
         
         [
-            "sv-SE", // According to the MS Style guidelines, quotes are usually not required in Swedish when the source English text contains quotes
-            "it-IT", // Based on feedback from linguists quotes in Italian are not required to be the guillemets, even though CLDR says so
+            "sv", // According to the MS Style guidelines, quotes are usually not required in Swedish when the source English text contains quotes
+            "it", // Based on feedback from linguists quotes in Italian are not required to be the guillemets, even though CLDR says so
         ].forEach(locale => this.skipLocales.add(locale));   
     }
 

--- a/src/rules/ResourceRule.js
+++ b/src/rules/ResourceRule.js
@@ -42,15 +42,24 @@ class ResourceRule extends Rule {
         super(options);
 
         /**
-         * @protected @type {Set<string>|undefined} Ensure that the rule is only applied to
-         * resources that match one of the lang-specs in the
-         * the set.
+         * Ensure that the rule is only applied to resources that match one of
+         * the lang-specs in the the set.
+         * 
+         * These should be language specifiers (e.g. "it", not "it-IT").
+         *
+         * @type {Set<string> | undefined}
+         * @protected
          */
         this.locales;
 
         /**
-         * @protected @type {Set<string>|undefined} Ensure that the rule is only applied to resources that do not match
+         * Ensure that the rule is only applied to resources that do not match
          * any of the lang-specs in the set.
+         * 
+         * These should be language specifiers (e.g. "it", not "it-IT").
+         *
+         * @type {Set<string> | undefined}
+         * @protected
          */
         this.skipLocales;
     }

--- a/test/ResourceQuoteStyle.test.js
+++ b/test/ResourceQuoteStyle.test.js
@@ -21,7 +21,7 @@ import { ResourceString } from 'ilib-tools-common';
 
 import ResourceQuoteStyle from "../src/rules/ResourceQuoteStyle.js";
 
-import { Result } from 'i18nlint-common';
+import { IntermediateRepresentation, Result } from 'i18nlint-common';
 
 describe("testResourceQuoteStyle", () => {
     test("ResourceQuoteStyle", () => {
@@ -488,6 +488,34 @@ describe("testResourceQuoteStyle", () => {
         expect(!actual).toBeTruthy();
     });
 
+    test("ResourceQuoteStyleItalianSkipped", () => {
+        expect.assertions(2);
+
+        const rule = new ResourceQuoteStyle();
+        expect(rule).toBeTruthy();
+
+        const resource = new ResourceString({
+            key: "quote.test",
+            sourceLocale: "en-US",
+            source: 'This string contains "quotes" in it.',
+            targetLocale: "it-IT",
+            target: "Questa stringa non contiene virgolette.",
+            pathName: "a/b/c.xliff"
+        });
+
+        const ir = new IntermediateRepresentation({
+            type: "resource",
+            ir: [resource],
+            filePath: "a/b/c.xliff"
+        });
+
+        const actual = rule.match({
+            ir,
+            file: "a/b/c.xliff"
+        });
+
+        expect(!actual).toBeTruthy();
+    });
 
     test("ResourceQuoteStyleMatchQuotesInTargetOnly", () => {
         expect.assertions(2);


### PR DESCRIPTION
Based on feedback from linguists, quotes in Italian are not required to be the guillemets, even though that is what it says in CLDR.

This PR disables quote style checking rule for Italian.