### PR TITLE
Fix incorrect error about quote style when there is a bracket next to the quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -525,6 +525,13 @@ limitations under the License.
 
 ## Release Notes
 
+### v1.14.0
+
+- added a new rule to check whether or not replacement parameters in the
+  source string are explained in the translator's comments.
+- fixed a bug where the quote style checker was not checking quotes properly
+  when the quotes surrounded a replacement parameter like "{this}"
+
 ### v1.13.1
 
 - fixed a bug with the sorting of results

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-lint",
-    "version": "1.13.1",
+    "version": "1.14.0",
     "module": "./src/index.js",
     "type": "module",
     "bin": "./src/index.js",

--- a/src/rules/ResourceQuoteStyle.js
+++ b/src/rules/ResourceQuoteStyle.js
@@ -30,9 +30,9 @@ let regExpsCache = {};
 const quoteChars = "«»‘“”„「」’‚‹›『』";
 
 // shared between all locales since there is nothing locale-specific in here
-const quotesAscii = new RegExp(`((^|\\W)"\\s?\\p{Letter}|\\p{Letter}\\s?"(\\W|$))`, "gu");
+const quotesAscii = new RegExp(`((^|\\W)"\\s?[\\p{Letter}\\{]|[\\p{Letter}\\}]\\s?"(\\W|$))`, "gu");
 // leave out the "s" before the final quote to take care of plural possessives (eg. my colleagues' files.)
-const quotesAsciiAlt = new RegExp(`((^|\\W)'\\s?\\p{Letter}|[a-rt-zA-RT-Z]\\s?'(\\W|$))`, "gu");
+const quotesAsciiAlt = new RegExp(`((^|\\W)'\\s?[\\p{Letter}\\{]|[a-rt-zA-RT-Z\\}]\\s?'(\\W|$))`, "gu");
 
 /**
  * @class Represent an ilib-lint rule.
@@ -93,20 +93,20 @@ class ResourceQuoteStyle extends ResourceRule {
         // match the appropriate regexp. The re1 and re2 are for the highlight field
         if (asciiMatches) {
             if (tar.match(regExps.target.quotesAll)) return;
-            re1 = new RegExp(`(^|\\W)([${regExps.target.nonQuoteChars}'])(\\p{Letter})`, "gu");
-            re2 = new RegExp(`(\\p{Letter})([${regExps.target.nonQuoteChars}'])(\\W|$)`, "gu");
+            re1 = new RegExp(`(^|\\W)([${regExps.target.nonQuoteChars}'])([\\p{Letter}\\{])`, "gu");
+            re2 = new RegExp(`([\\p{Letter}\\}])([${regExps.target.nonQuoteChars}'])(\\W|$)`, "gu");
         } else if (asciiMatchesAlt) {
             if (tar.match(regExps.target.quotesAllAlt)) return;
-            re1 = new RegExp(`(^|\\W)[${regExps.target.nonQuoteCharsAlt}"](\\p{Letter})`, "gu");
-            re2 = new RegExp(`(\\p{Letter})([${regExps.target.nonQuoteCharsAlt}"])(\\W|$)`, "gu");
+            re1 = new RegExp(`(^|\\W)[${regExps.target.nonQuoteCharsAlt}"]([\\p{Letter}\\{])`, "gu");
+            re2 = new RegExp(`([\\p{Letter}\\}])([${regExps.target.nonQuoteCharsAlt}"])(\\W|$)`, "gu");
         } else if (nativeMatches) {
             if (tar.match(regExps.target.quotesNative)) return;
-            re1 = new RegExp(`(^|\\W)([${regExps.target.nonQuoteChars}'"])(\\p{Letter})`, "gu");
-            re2 = new RegExp(`(\\p{Letter})([${regExps.target.nonQuoteChars}'"])(\\W|$)`, "gu");
+            re1 = new RegExp(`(^|\\W)([${regExps.target.nonQuoteChars}'"])([\\p{Letter}\\{])`, "gu");
+            re2 = new RegExp(`([\\p{Letter}\\}])([${regExps.target.nonQuoteChars}'"])(\\W|$)`, "gu");
         } else if (nativeMatchesAlt) {
             if (tar.match(regExps.target.quotesNativeAlt)) return;
-            re1 = new RegExp(`(^|\\W)([${regExps.target.nonQuoteCharsAlt}'"])(\\p{Letter})`, "gu");
-            re2 = new RegExp(`(\\p{Letter})([${regExps.target.nonQuoteCharsAlt}'"])(\\W|$)`, "gu");
+            re1 = new RegExp(`(^|\\W)([${regExps.target.nonQuoteCharsAlt}'"])([\\p{Letter}\\{])`, "gu");
+            re2 = new RegExp(`([\\p{Letter}\\}])([${regExps.target.nonQuoteCharsAlt}'"])(\\W|$)`, "gu");
         }
         const matches1 = re1 ? re1.exec(tar) : undefined;
         const matches2 = re2 ? re2.exec(tar) : undefined;
@@ -175,19 +175,19 @@ class ResourceQuoteStyle extends ResourceRule {
 
         // now calculate regular expressions for the source string that use those quotes
         // if the source uses ASCII quotes, then the target could have ASCII or native quotes
-        regExps.source.quotesNative = new RegExp(`((^|\\W)${regExps.source.quoteStart}\\s?\\p{Letter}|\\p{Letter}\\s?${regExps.source.quoteEnd}(\\W|$))`, "gu");
-        regExps.source.quotesNativeAlt = new RegExp(`((^|\\W)${regExps.source.quoteStartAlt}\\s?\\p{Letter}|\\p{Letter}\\s?${regExps.source.quoteEndAlt}(\\W|$))`, "gu");
+        regExps.source.quotesNative = new RegExp(`((^|\\W)${regExps.source.quoteStart}\\s?[\\p{Letter}\\{]|[\\p{Letter}\\}]\\s?${regExps.source.quoteEnd}(\\W|$))`, "gu");
+        regExps.source.quotesNativeAlt = new RegExp(`((^|\\W)${regExps.source.quoteStartAlt}\\s?[\\p{Letter}\\{]|[\\p{Letter}\\}]\\s?${regExps.source.quoteEndAlt}(\\W|$))`, "gu");
 
         // now calculate the regular expressions for the target string that use quotes
         // if the source contains native quotes, then the target should also have native quotes
-        regExps.target.quotesNative = new RegExp(`((^|\\W)${regExps.target.quoteStart}\\s?\\p{Letter}|\\p{Letter}\\s?${regExps.target.quoteEnd}(\\W|$))`, "gu");
-        regExps.target.quotesNativeAlt = new RegExp(`((^|\\W)${regExps.target.quoteStartAlt}\\s?\\p{Letter}|\\p{Letter}\\s?${regExps.target.quoteEndAlt}(\\W|$))`, "gu");
+        regExps.target.quotesNative = new RegExp(`((^|\\W)${regExps.target.quoteStart}\\s?[\\p{Letter}\\{]|[\\p{Letter}\\}]\\s?${regExps.target.quoteEnd}(\\W|$))`, "gu");
+        regExps.target.quotesNativeAlt = new RegExp(`((^|\\W)${regExps.target.quoteStartAlt}\\s?[\\p{Letter}\\{]|[\\p{Letter}\\}]\\s?${regExps.target.quoteEndAlt}(\\W|$))`, "gu");
         regExps.target.quotesAll = this.localeOnly ?
             regExps.target.quotesNative :
-            new RegExp(`((^|\\W)[${regExps.target.quoteStart}${regExps.target.quoteStartAlt}"]\\s?\\p{Letter}|\\p{Letter}\\s?[${regExps.target.quoteEnd}${regExps.target.quoteEndAlt}"](\\W|$))`, "gu");
+            new RegExp(`((^|\\W)[${regExps.target.quoteStart}${regExps.target.quoteStartAlt}"]\\s?[\\p{Letter}\\{]|[\\p{Letter}\\}]\\s?[${regExps.target.quoteEnd}${regExps.target.quoteEndAlt}"](\\W|$))`, "gu");
         regExps.target.quotesAllAlt = this.localeOnly ?
             regExps.target.quotesNativeAlt :
-            new RegExp(`((^|\\W)[${regExps.target.quoteStartAlt}']\\s?\\p{Letter}|\\p{Letter}\\s?[${regExps.target.quoteEndAlt}'](\\W|$))`, "gu");
+            new RegExp(`((^|\\W)[${regExps.target.quoteStartAlt}']\\s?[\\p{Letter}\\{]|[\\p{Letter}\\}]\\s?[${regExps.target.quoteEndAlt}'](\\W|$))`, "gu");
 
         // the non quote chars are used to highlight errors in the target string
         regExps.target.nonQuoteChars = quoteChars.

--- a/test/ResourceQuoteStyle.test.js
+++ b/test/ResourceQuoteStyle.test.js
@@ -373,6 +373,28 @@ describe("testResourceQuoteStyle", () => {
         expect(!actual).toBeTruthy();
     });
 
+    test("ResourceQuoteStyleQuotesAdjacentReplacementParamBracket", () => {
+        const rule = new ResourceQuoteStyle();
+
+        const resource = new ResourceString({
+            key: "quote.test",
+            sourceLocale: "en-US",
+            source: `Showing {maxAmount} entries, "{sourceName}" has more.`,
+            targetLocale: "fr-FR",
+            target: `Affichant {maxAmount} entrées, « {sourceName} » en contient davantage.`,
+            pathName: "a/b/c.xliff"
+        });
+
+        const result = rule.matchString({
+            source: /** @type {string} */ (resource.getSource()),
+            target: /** @type {string} */ (resource.getTarget()),
+            resource,
+            file: "a/b/c.xliff"
+        });
+        
+        expect(result).toBeFalsy();
+    });
+
     test("ResourceQuoteStyleFrenchGuillemets", () => {
         expect.assertions(2);
 

--- a/test/ResourceQuoteStyle.test.js
+++ b/test/ResourceQuoteStyle.test.js
@@ -391,7 +391,86 @@ describe("testResourceQuoteStyle", () => {
             resource,
             file: "a/b/c.xliff"
         });
-        
+
+        expect(result).toBeFalsy();
+    });
+
+    test("ResourceQuoteStyleQuotesAdjacentReplacementParamBracket no quotes in translation", () => {
+        const rule = new ResourceQuoteStyle();
+
+        const resource = new ResourceString({
+            key: "quote.test",
+            sourceLocale: "en-US",
+            source: `Showing {maxAmount} entries, "{sourceName}" has more.`,
+            targetLocale: "fr-FR",
+            target: `Affichant {maxAmount} entrées, {sourceName} en contient davantage.`,
+            pathName: "a/b/c.xliff"
+        });
+
+        const result = rule.matchString({
+            source: /** @type {string} */ (resource.getSource()),
+            target: /** @type {string} */ (resource.getTarget()),
+            resource,
+            file: "a/b/c.xliff"
+        });
+
+        expect(result).toBeTruthy();
+
+        const expected = new Result({
+            severity: "warning",
+            description: "Quotes are missing in the target. Quote style for the locale fr-FR should be «text»",
+            id: "quote.test",
+            source: 'Showing {maxAmount} entries, "{sourceName}" has more.',
+            highlight: 'Target: Affichant {maxAmount} entrées, {sourceName} en contient davantage.<e0></e0>',
+            rule,
+            locale: "fr-FR",
+            pathName: "a/b/c.xliff"
+        });
+
+        expect(result).toStrictEqual(expected);
+    });
+
+    test("ResourceQuoteStyleQuotesAdjacentReplacementParamBracket with single quotes in source", () => {
+        const rule = new ResourceQuoteStyle();
+
+        const resource = new ResourceString({
+            key: "quote.test",
+            sourceLocale: "en-US",
+            source: `Showing {maxAmount} entries, '{sourceName}' has more.`,
+            targetLocale: "fr-FR",
+            target: `Affichant {maxAmount} entrées, « {sourceName} » en contient davantage.`,
+            pathName: "a/b/c.xliff"
+        });
+
+        const result = rule.matchString({
+            source: /** @type {string} */ (resource.getSource()),
+            target: /** @type {string} */ (resource.getTarget()),
+            resource,
+            file: "a/b/c.xliff"
+        });
+
+        expect(result).toBeFalsy();
+    });
+
+    test("ResourceQuoteStyleQuotesAdjacentReplacementParamBracket with single quotes in translation", () => {
+        const rule = new ResourceQuoteStyle();
+
+        const resource = new ResourceString({
+            key: "quote.test",
+            sourceLocale: "en-US",
+            source: `Showing {maxAmount} entries, '{sourceName}' has more.`,
+            targetLocale: "fr-FR",
+            target: `Affichant {maxAmount} entrées, '{sourceName}' en contient davantage.`,
+            pathName: "a/b/c.xliff"
+        });
+
+        const result = rule.matchString({
+            source: /** @type {string} */ (resource.getSource()),
+            target: /** @type {string} */ (resource.getTarget()),
+            resource,
+            file: "a/b/c.xliff"
+        });
+
         expect(result).toBeFalsy();
     });
 

--- a/test/ResourceQuoteStyle.test.js
+++ b/test/ResourceQuoteStyle.test.js
@@ -395,6 +395,28 @@ describe("testResourceQuoteStyle", () => {
         expect(result).toBeFalsy();
     });
 
+    test("ResourceQuoteStyleQuotesAdjacentReplacementParamBracket with fancy quotes in source", () => {
+        const rule = new ResourceQuoteStyle();
+
+        const resource = new ResourceString({
+            key: "quote.test",
+            sourceLocale: "en-US",
+            source: `Showing {maxAmount} entries, “{sourceName}” has more.`,
+            targetLocale: "fr-FR",
+            target: `Affichant {maxAmount} entrées, « {sourceName} » en contient davantage.`,
+            pathName: "a/b/c.xliff"
+        });
+
+        const result = rule.matchString({
+            source: /** @type {string} */ (resource.getSource()),
+            target: /** @type {string} */ (resource.getTarget()),
+            resource,
+            file: "a/b/c.xliff"
+        });
+
+        expect(result).toBeFalsy();
+    });
+
     test("ResourceQuoteStyleQuotesAdjacentReplacementParamBracket no quotes in translation", () => {
         const rule = new ResourceQuoteStyle();
 
@@ -421,6 +443,41 @@ describe("testResourceQuoteStyle", () => {
             description: "Quotes are missing in the target. Quote style for the locale fr-FR should be «text»",
             id: "quote.test",
             source: 'Showing {maxAmount} entries, "{sourceName}" has more.',
+            highlight: 'Target: Affichant {maxAmount} entrées, {sourceName} en contient davantage.<e0></e0>',
+            rule,
+            locale: "fr-FR",
+            pathName: "a/b/c.xliff"
+        });
+
+        expect(result).toStrictEqual(expected);
+    });
+
+    test("ResourceQuoteStyleQuotesAdjacentReplacementParamBracket fancy quotes in source and no quotes in translation", () => {
+        const rule = new ResourceQuoteStyle();
+
+        const resource = new ResourceString({
+            key: "quote.test",
+            sourceLocale: "en-US",
+            source: `Showing {maxAmount} entries, “{sourceName}” has more.`,
+            targetLocale: "fr-FR",
+            target: `Affichant {maxAmount} entrées, {sourceName} en contient davantage.`,
+            pathName: "a/b/c.xliff"
+        });
+
+        const result = rule.matchString({
+            source: /** @type {string} */ (resource.getSource()),
+            target: /** @type {string} */ (resource.getTarget()),
+            resource,
+            file: "a/b/c.xliff"
+        });
+
+        expect(result).toBeTruthy();
+
+        const expected = new Result({
+            severity: "warning",
+            description: "Quotes are missing in the target. Quote style for the locale fr-FR should be «text»",
+            id: "quote.test",
+            source: 'Showing {maxAmount} entries, “{sourceName}” has more.',
             highlight: 'Target: Affichant {maxAmount} entrées, {sourceName} en contient davantage.<e0></e0>',
             rule,
             locale: "fr-FR",


### PR DESCRIPTION
If the translation has a punctuation character next to the quote instead of a letter, then the quote style rule will trigger erroneously. Example:

Source:
> Showing {maxAmount} entries, "{sourceName}" has more.

Target:
> Affichant {maxAmount} entrées, « {sourceName} » en contient davantage.

This should not produce an error.